### PR TITLE
Allow plugins to specify multiple authors

### DIFF
--- a/src/main/java/net/clgd/ccemux/plugins/Plugin.java
+++ b/src/main/java/net/clgd/ccemux/plugins/Plugin.java
@@ -92,10 +92,10 @@ public abstract class Plugin {
 	public abstract Optional<String> getVersion();
 
 	/**
-	 * The authors of the plugin. If an empty <code>Set</code> is returned,
+	 * The authors of the plugin. If an empty <code>Collection</code> is returned,
 	 * no authors will be shown to end-users.
 	 */
-	public abstract Set<String> getAuthors();
+	public abstract Collection<String> getAuthors();
 
 	/**
 	 * Gets the website for this plugin. This can be a link to a forum thread, a

--- a/src/main/java/net/clgd/ccemux/plugins/Plugin.java
+++ b/src/main/java/net/clgd/ccemux/plugins/Plugin.java
@@ -13,7 +13,7 @@ import net.clgd.ccemux.plugins.hooks.Hook;
  * Represents a plugin for CCEmuX. Plugins can add or change behavior, such as
  * adding Lua APIs, adding rendering systems, or even changing the behavior of
  * CC itself. (albeit through classloader hacks)
- * 
+ *
  * @author apemanzilla
  * @see Hook
  */
@@ -23,7 +23,7 @@ public abstract class Plugin {
 
 	/**
 	 * Gets all the hooks this plugin has registered
-	 * 
+	 *
 	 * @see Hook
 	 */
 	public final Set<Hook> getHooks() {
@@ -32,7 +32,7 @@ public abstract class Plugin {
 
 	/**
 	 * Gets all the hooks this plugin has registered of a specific type
-	 * 
+	 *
 	 * @param cls
 	 *            The type
 	 * @return
@@ -58,7 +58,7 @@ public abstract class Plugin {
 	 * parameter is only used to help out with type inference so that lambdas
 	 * can be used.<br />
 	 * <br />
-	 * 
+	 *
 	 * @deprecated Using this method with lambdas as opposed to
 	 *             {@link #registerHook(Hook)} with anonymous classes may cause
 	 *             crashes, as lambdas force the JVM to load classes earlier
@@ -66,7 +66,7 @@ public abstract class Plugin {
 	 *             {@link ClassNotFoundException} because of the way
 	 *             ComputerCraft is loaded at runtime. This method will most
 	 *             likely be removed in the future.
-	 * 
+	 *
 	 * @see Hook
 	 * @see #registerHook(Hook)
 	 */
@@ -92,17 +92,17 @@ public abstract class Plugin {
 	public abstract Optional<String> getVersion();
 
 	/**
-	 * The author of the plugin. If an empty <code>Optional</code> is returned,
-	 * no author will be shown to end-users.
+	 * The authors of the plugin. If an empty <code>Set</code> is returned,
+	 * no authors will be shown to end-users.
 	 */
-	public abstract Optional<String> getAuthor();
+	public abstract Set<String> getAuthors();
 
 	/**
 	 * Gets the website for this plugin. This can be a link to a forum thread, a
 	 * wiki, source code, or anything else that may be helpful to end-users. If
 	 * an empty <code>Optional</code> is returned, no website will be shown to
 	 * end-users.
-	 * 
+	 *
 	 */
 	public abstract Optional<String> getWebsite();
 
@@ -111,7 +111,7 @@ public abstract class Plugin {
 	 * This method is intended to be used to interact with the classloader
 	 * before CC is loaded and should not be used unless you know what you're
 	 * doing!
-	 * 
+	 *
 	 * @see #setup()
 	 */
 	public void loaderSetup(EmuConfig cfg, ClassLoader loader) {};
@@ -124,7 +124,7 @@ public abstract class Plugin {
 	 * should use the
 	 * {@link net.clgd.ccemux.plugins.hooks.InitializationCompleted
 	 * InitializationCompleted} hook.
-	 * 
+	 *
 	 * @see Hook
 	 */
 	public abstract void setup(EmuConfig cfg);
@@ -135,7 +135,7 @@ public abstract class Plugin {
 
 	/**
 	 * Attempts to locate the file that this plugin was loaded from
-	 * 
+	 *
 	 * @return
 	 */
 	public final Optional<File> getSource() {

--- a/src/main/java/net/clgd/ccemux/plugins/builtin/AWTPlugin.java
+++ b/src/main/java/net/clgd/ccemux/plugins/builtin/AWTPlugin.java
@@ -1,9 +1,11 @@
 package net.clgd.ccemux.plugins.builtin;
 
 import java.util.Optional;
+import java.util.Set;
 
 import com.google.auto.service.AutoService;
 
+import com.google.common.collect.Sets;
 import net.clgd.ccemux.emulation.EmuConfig;
 import net.clgd.ccemux.plugins.Plugin;
 import net.clgd.ccemux.rendering.RendererFactory;
@@ -27,8 +29,8 @@ public class AWTPlugin extends Plugin {
 	}
 
 	@Override
-	public Optional<String> getAuthor() {
-		return Optional.of("CLGD");
+	public Set<String> getAuthors() {
+		return Sets.newHashSet("CLGD");
 	}
 
 	@Override

--- a/src/main/java/net/clgd/ccemux/plugins/builtin/AWTPlugin.java
+++ b/src/main/java/net/clgd/ccemux/plugins/builtin/AWTPlugin.java
@@ -1,11 +1,12 @@
 package net.clgd.ccemux.plugins.builtin;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 
 import com.google.auto.service.AutoService;
 
-import com.google.common.collect.Sets;
 import net.clgd.ccemux.emulation.EmuConfig;
 import net.clgd.ccemux.plugins.Plugin;
 import net.clgd.ccemux.rendering.RendererFactory;
@@ -29,8 +30,8 @@ public class AWTPlugin extends Plugin {
 	}
 
 	@Override
-	public Set<String> getAuthors() {
-		return Sets.newHashSet("CLGD");
+	public Collection<String> getAuthors() {
+		return Collections.singleton("CLGD");
 	}
 
 	@Override

--- a/src/main/java/net/clgd/ccemux/plugins/builtin/CCEmuXAPI.java
+++ b/src/main/java/net/clgd/ccemux/plugins/builtin/CCEmuXAPI.java
@@ -142,8 +142,8 @@ public class CCEmuXAPI extends Plugin {
 	}
 
 	@Override
-	public Set<String> getAuthors() {
-		return new HashSet<>();
+	public Collection<String> getAuthors() {
+		return Collections.emptyList();
 	}
 
 	@Override

--- a/src/main/java/net/clgd/ccemux/plugins/builtin/CCEmuXAPI.java
+++ b/src/main/java/net/clgd/ccemux/plugins/builtin/CCEmuXAPI.java
@@ -142,8 +142,8 @@ public class CCEmuXAPI extends Plugin {
 	}
 
 	@Override
-	public Optional<String> getAuthor() {
-		return Optional.empty();
+	public Set<String> getAuthors() {
+		return new HashSet<>();
 	}
 
 	@Override

--- a/src/main/java/net/clgd/ccemux/plugins/builtin/CCTweaksPlugin.java
+++ b/src/main/java/net/clgd/ccemux/plugins/builtin/CCTweaksPlugin.java
@@ -2,9 +2,11 @@ package net.clgd.ccemux.plugins.builtin;
 
 import java.awt.GraphicsEnvironment;
 import java.util.Optional;
+import java.util.Set;
 
 import javax.swing.JOptionPane;
 
+import com.google.common.collect.Sets;
 import org.squiddev.cctweaks.lua.TweaksLogger;
 import org.squiddev.cctweaks.lua.launch.RewritingLoader;
 import org.squiddev.cctweaks.lua.lib.ApiRegister;
@@ -34,8 +36,8 @@ public class CCTweaksPlugin extends Plugin {
 	}
 
 	@Override
-	public Optional<String> getAuthor() {
-		return Optional.of("SquidDev");
+	public Set<String> getAuthors() {
+		return Sets.newHashSet("SquidDev");
 	}
 
 	@Override

--- a/src/main/java/net/clgd/ccemux/plugins/builtin/CCTweaksPlugin.java
+++ b/src/main/java/net/clgd/ccemux/plugins/builtin/CCTweaksPlugin.java
@@ -1,12 +1,13 @@
 package net.clgd.ccemux.plugins.builtin;
 
 import java.awt.GraphicsEnvironment;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 
 import javax.swing.JOptionPane;
 
-import com.google.common.collect.Sets;
 import org.squiddev.cctweaks.lua.TweaksLogger;
 import org.squiddev.cctweaks.lua.launch.RewritingLoader;
 import org.squiddev.cctweaks.lua.lib.ApiRegister;
@@ -36,8 +37,8 @@ public class CCTweaksPlugin extends Plugin {
 	}
 
 	@Override
-	public Set<String> getAuthors() {
-		return Sets.newHashSet("SquidDev");
+	public Collection<String> getAuthors() {
+		return Collections.singleton("SquidDev");
 	}
 
 	@Override

--- a/src/main/java/net/clgd/ccemux/plugins/builtin/HDFontPlugin.java
+++ b/src/main/java/net/clgd/ccemux/plugins/builtin/HDFontPlugin.java
@@ -2,9 +2,11 @@ package net.clgd.ccemux.plugins.builtin;
 
 import java.io.IOException;
 import java.util.Optional;
+import java.util.Set;
 
 import com.google.auto.service.AutoService;
 
+import com.google.common.collect.Sets;
 import lombok.extern.slf4j.Slf4j;
 import net.clgd.ccemux.emulation.EmuConfig;
 import net.clgd.ccemux.plugins.Plugin;
@@ -29,8 +31,8 @@ public class HDFontPlugin extends Plugin {
 	}
 
 	@Override
-	public Optional<String> getAuthor() {
-		return Optional.of("BombBloke");
+	public Set<String> getAuthors() {
+		return Sets.newHashSet("BombBloke");
 	}
 
 	@Override

--- a/src/main/java/net/clgd/ccemux/plugins/builtin/HDFontPlugin.java
+++ b/src/main/java/net/clgd/ccemux/plugins/builtin/HDFontPlugin.java
@@ -1,12 +1,13 @@
 package net.clgd.ccemux.plugins.builtin;
 
 import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 
 import com.google.auto.service.AutoService;
 
-import com.google.common.collect.Sets;
 import lombok.extern.slf4j.Slf4j;
 import net.clgd.ccemux.emulation.EmuConfig;
 import net.clgd.ccemux.plugins.Plugin;
@@ -31,8 +32,8 @@ public class HDFontPlugin extends Plugin {
 	}
 
 	@Override
-	public Set<String> getAuthors() {
-		return Sets.newHashSet("BombBloke");
+	public Collection<String> getAuthors() {
+		return Collections.singleton("BombBloke");
 	}
 
 	@Override

--- a/src/main/java/net/clgd/ccemux/plugins/builtin/TRoRPlugin.java
+++ b/src/main/java/net/clgd/ccemux/plugins/builtin/TRoRPlugin.java
@@ -1,9 +1,11 @@
 package net.clgd.ccemux.plugins.builtin;
 
 import java.util.Optional;
+import java.util.Set;
 
 import com.google.auto.service.AutoService;
 
+import com.google.common.collect.Sets;
 import net.clgd.ccemux.emulation.EmuConfig;
 import net.clgd.ccemux.plugins.Plugin;
 import net.clgd.ccemux.rendering.RendererFactory;
@@ -27,8 +29,8 @@ public class TRoRPlugin extends Plugin {
 	}
 
 	@Override
-	public Optional<String> getAuthor() {
-		return Optional.of("CLGD");
+	public Set<String> getAuthors() {
+		return Sets.newHashSet("CLGD");
 	}
 
 	@Override

--- a/src/main/java/net/clgd/ccemux/plugins/builtin/TRoRPlugin.java
+++ b/src/main/java/net/clgd/ccemux/plugins/builtin/TRoRPlugin.java
@@ -1,11 +1,12 @@
 package net.clgd.ccemux.plugins.builtin;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 
 import com.google.auto.service.AutoService;
 
-import com.google.common.collect.Sets;
 import net.clgd.ccemux.emulation.EmuConfig;
 import net.clgd.ccemux.plugins.Plugin;
 import net.clgd.ccemux.rendering.RendererFactory;
@@ -29,8 +30,8 @@ public class TRoRPlugin extends Plugin {
 	}
 
 	@Override
-	public Set<String> getAuthors() {
-		return Sets.newHashSet("CLGD");
+	public Collection<String> getAuthors() {
+		return Collections.singleton("CLGD");
 	}
 
 	@Override


### PR DESCRIPTION
Plugins don't necessarily have just a single author. I've changed `Optional<String> Plugin.getAuthor()` to ~`Set<String> Plugin.getAuthors()`~ `Collection<String> Plugin.getAuthors()`.