### PR TITLE
Experimental config system

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,10 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
+[*.lua]
+indent_style = space
+indent_size = 4
+
 [*.md]
 trim_trailing_whitespace = false
 

--- a/src/main/java/net/clgd/ccemux/config/Config.java
+++ b/src/main/java/net/clgd/ccemux/config/Config.java
@@ -1,205 +1,56 @@
 package net.clgd.ccemux.config;
 
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.BiConsumer;
+import com.google.gson.reflect.TypeToken;
+import lombok.Getter;
 
-import com.google.common.collect.Multimap;
-import com.google.common.collect.MultimapBuilder;
-import com.google.common.collect.Multimaps;
-import com.google.gson.Gson;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonSyntaxException;
-
-import lombok.Value;
-import lombok.experimental.NonFinal;
-
-@Value
-@NonFinal
+/**
+ * The base class for all config files.
+ */
 public class Config {
-	@Value
-	private class ChangeListener<T> {
-		Class<T> cls;
-		BiConsumer<T, T> listener;
-	}
-
-	private final Gson gson;
-
 	/**
-	 * Gets the underlying map of this config. Modifications to this map will affect
-	 * the config, but will <b>not</b> fire listeners.
+	 * The root group for the config. All properties and child groups
+	 * are stored in this.
 	 */
-	private final Map<String, JsonElement> data;
+	@Getter
+	private final Group root = new Group();
+
 
 	/**
-	 * Gets the listeners for this config.<br>
-	 * <br>
-	 * Listeners contain a class representing the target value type, and a
-	 * biconsumer which is passed the old value and new value as parameters.
-	 */
-	private final Multimap<String, ChangeListener<?>> listeners = Multimaps
-			.synchronizedSetMultimap(MultimapBuilder.hashKeys().hashSetValues().build());
-
-	public Config(Gson gson, Map<String, JsonElement> data) {
-		this.gson = gson;
-		this.data = new ConcurrentHashMap<>();
-		this.data.putAll(data);
-	}
-
-	/**
-	 * A wrapper for a specific key and value in a config
-	 * 
-	 * @author apemanzilla
+	 * Create a new property with the given key and add it to the config file.
 	 *
-	 * @param <T>
-	 *            The type of value stored
+	 * @param key          The property's unique key.
+	 * @param type         The type of this property's value.
+	 * @param defaultValue The default value of this property.
+	 * @return The newly created property.
+	 * @throws IllegalStateException If an entry with the same key exists.
+	 * @see Property#Property(String, TypeToken, Object)
 	 */
-	@Value
-	public class Property<T> {
-		String key;
-		Class<T> type;
-		T defaultValue;
-
-		/**
-		 * Adds a listener to be invoked when this value is changed, which is passed the
-		 * old and new values respectively.
-		 */
-		public void addListener(BiConsumer<T, T> consumer) {
-			Config.this.addListener(key, type, consumer);
-		}
-
-		/**
-		 * Removes a listener
-		 */
-		public void removeListener(BiConsumer<T, T> consumer) {
-			Config.this.removeListener(key, consumer);
-		}
-
-		/**
-		 * Gets the raw value of this property, even if it's <code>null</code>.
-		 */
-		public T getNullable() {
-			return getAs(key, type).orElse(null);
-		}
-
-		/**
-		 * Gets the value of this property, or the default value if the value is
-		 * <code>null</code>.
-		 * 
-		 * @return
-		 */
-		public T get() {
-			return getAsOr(key, type, defaultValue);
-		}
-
-		/**
-		 * Sets the value of this property.
-		 */
-		public void set(T value) {
-			put(key, value);
-		}
+	public <T> Property<T> property(String key, TypeToken<T> type, T defaultValue) {
+		return root.property(key, type, defaultValue);
 	}
 
 	/**
-	 * Adds a listener which is invoked whenever the given config property is
-	 * changed.
-	 * 
-	 * @param cls
-	 *            The type of value to be deserialized and passed to the consumer.
-	 * @param consumer
-	 *            A consumer that takes the old and new values (respectively) of the
-	 *            property that has changed.
+	 * Create a new property with the given key and add it to the config file.
+	 *
+	 * @param key          The property's unique key.
+	 * @param type         The type of this property's value.
+	 * @param defaultValue The default value of this property.
+	 * @return The newly created property.
+	 * @throws IllegalStateException If an entry with the same key exists.
+	 * @see Property#Property(String, Class, Object)
 	 */
-	public <T> void addListener(String key, Class<T> cls, BiConsumer<T, T> consumer) {
-		listeners.put(key, new ChangeListener<T>(cls, consumer));
-	}
-
-	public <T> void removeListener(String key, BiConsumer<T, T> consumer) {
-		listeners.get(key).removeIf(c -> c.listener.equals(consumer));
-	}
-
-	public <T> void removeListener(BiConsumer<T, T> consumer) {
-		listeners.values().removeIf(c -> c.listener.equals(consumer));
+	public <T> Property<T> property(String key, Class<T> type, T defaultValue) {
+		return root.property(key, type, defaultValue);
 	}
 
 	/**
-	 * A set of keys present in this config. Modifications to this set will not
-	 * affect the config.
+	 * Lookup a group with the given key, or create a new one.
+	 *
+	 * @param key The group's key.
+	 * @return A group with the given key.
+	 * @throws IllegalStateException If a _property_ with the same name exists.
 	 */
-	public Set<String> keys() {
-		return new HashSet<>(data.keySet());
-	}
-
-	/**
-	 * @return Whether the config contains a value for the given key.
-	 */
-	public boolean containsKey(String key) {
-		return data.containsKey(key);
-	}
-
-	/**
-	 * @return The raw {@link JsonElement} value at the given key, or an empty
-	 *         <code>Optional</code> if no value is present for this key.
-	 */
-	public Optional<JsonElement> getRaw(String key) {
-		return Optional.ofNullable(data.get(key));
-	}
-
-	/**
-	 * @return The value for the given key, as a type specified by the
-	 *         <code>cls</code> parameter.
-	 */
-	public <T> Optional<T> getAs(String key, Class<T> cls) throws JsonSyntaxException {
-		return getRaw(key).map(j -> gson.fromJson(j, cls));
-	}
-
-	/**
-	 * 
-	 * @return The value for the given key, as a type specified by the
-	 *         <code>cls</code> parameter, or the given default value if no value is
-	 *         available for the given key.
-	 */
-	public <T> T getAsOr(String key, Class<T> cls, T defaultValue) {
-		return getAs(key, cls).orElse(defaultValue);
-	}
-
-	@SuppressWarnings({ "unchecked", "rawtypes" })
-	private void invokeListeners(String key, JsonElement from, JsonElement to) {
-		listeners.get(key).stream().map(c -> (ChangeListener) c).forEach(c -> {
-			c.listener.accept(gson.fromJson(from, c.cls), gson.fromJson(to, c.cls));
-		});
-	}
-
-	/**
-	 * Removes the value for the given key from this config.
-	 */
-	public void remove(String key) {
-		JsonElement old = getRaw(key).orElse(null);
-		data.remove(key);
-		invokeListeners(key, old, null);
-	}
-
-	/**
-	 * Adds a raw JSON element for the given key, overwriting any existing values.
-	 */
-	public void putRaw(String key, JsonElement e) {
-		JsonElement old = getRaw(key).orElse(null);
-		data.put(key, e);
-		invokeListeners(key, old, e);
-	}
-
-	/**
-	 * Adds a given element to the config for the given key, overwriting any
-	 * existing values.
-	 */
-	public <T> void put(String key, T t) {
-		putRaw(key, gson.toJsonTree(t));
-	}
-
-	public <T> Property<T> property(String key, Class<T> cls, T defaultValue) {
-		return new Property<>(key, cls, defaultValue);
+	public Group group(String key) {
+		return root.group(key);
 	}
 }

--- a/src/main/java/net/clgd/ccemux/config/ConfigEntry.java
+++ b/src/main/java/net/clgd/ccemux/config/ConfigEntry.java
@@ -1,0 +1,34 @@
+package net.clgd.ccemux.config;
+
+import java.util.Optional;
+
+/**
+ * A keyed entry in a config file.
+ *
+ * @see Group
+ * @see Property
+ */
+public abstract class ConfigEntry {
+	ConfigEntry() {}
+
+	/**
+	 * Get the unique key for this entry.
+	 *
+	 * @return The entry's key.
+	 */
+	public abstract String getKey();
+
+	/**
+	 * Get a friendly name for this entry.
+	 *
+	 * @return A friendly name, defaulting to {@link #getKey()} if none is set.
+	 */
+	public abstract String getName();
+
+	/**
+	 * Get a short description of what this entry does.
+	 *
+	 * @return A short description.
+	 */
+	public abstract Optional<String> getDescription();
+}

--- a/src/main/java/net/clgd/ccemux/config/Group.java
+++ b/src/main/java/net/clgd/ccemux/config/Group.java
@@ -1,0 +1,148 @@
+package net.clgd.ccemux.config;
+
+import java.util.*;
+
+import com.google.gson.reflect.TypeToken;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import lombok.val;
+
+/**
+ * A group acts as a collection of child properties and groups, allowing
+ * for greater organisation of config files.
+ *
+ * @see ConfigEntry
+ * @see Property
+ */
+@Accessors(chain = true)
+public class Group extends ConfigEntry {
+	@Getter
+	private final String key;
+
+	@Getter
+	@Setter
+	private String name;
+
+	@Setter
+	private String description;
+
+	private final Map<String, ConfigEntry> children = new LinkedHashMap<>();
+
+	public Group(String key) {
+		this.key = key;
+		this.name = key;
+	}
+
+	Group() {
+		this("");
+	}
+
+	/**
+	 * Add a new property to this group.
+	 *
+	 * @param property The property to add.
+	 * @return The current group ({@code this}).
+	 * @throws IllegalStateException If an entry with the same key already exists.
+	 */
+	public Group addProperty(Property<?> property) {
+		if (children.containsKey(property.getKey())) {
+			throw new IllegalStateException("Already an entry with the given key");
+		}
+
+		children.put(property.getKey(), property);
+		return this;
+	}
+
+	/**
+	 * Add a new child group to this group.
+	 *
+	 * @param group The group to add.
+	 * @return The current group ({@code this}).
+	 * @throws IllegalStateException If an entry with the same key already exists.
+	 */
+	public Group addGroup(Group group) {
+		if (children.containsKey(group.getKey())) {
+			throw new IllegalStateException("Already an entry with the given key");
+		}
+
+		children.put(group.getKey(), group);
+		return this;
+	}
+
+	/**
+	 * Get all children in this group.
+	 *
+	 * @return An unmodifiable collection of children.
+	 */
+	public Collection<ConfigEntry> children() {
+		return Collections.unmodifiableCollection(children.values());
+	}
+
+	/**
+	 * Get a child with the given key.
+	 *
+	 * @param key The key for the corresponding child.
+	 * @return The child entry if it exists.
+	 */
+	public Optional<ConfigEntry> child(String key) {
+		return Optional.ofNullable(children.get(key));
+	}
+
+	@Override
+	public Optional<String> getDescription() {
+		return Optional.ofNullable(description);
+	}
+
+	/**
+	 * Create a new property with the given key and add it to the group.
+	 *
+	 * @param key          The property's unique key.
+	 * @param type         The type of this property's value.
+	 * @param defaultValue The default value of this property.
+	 * @return The newly created property.
+	 * @throws IllegalStateException If an entry with the same key exists.
+	 * @see Property#Property(String, TypeToken, Object)
+	 */
+	public <T> Property<T> property(String key, TypeToken<T> type, T defaultValue) {
+		Property<T> property = new Property<>(key, type, defaultValue);
+		addProperty(property);
+		return property;
+	}
+
+	/**
+	 * Create a new property with the given key and add it to the group.
+	 *
+	 * @param key          The property's unique key.
+	 * @param type         The type of this property's value.
+	 * @param defaultValue The default value of this property.
+	 * @return The newly created property.
+	 * @throws IllegalStateException If an entry with the same key exists.
+	 * @see Property#Property(String, Class, Object)
+	 */
+	public <T> Property<T> property(String key, Class<T> type, T defaultValue) {
+		Property<T> property = new Property<>(key, type, defaultValue);
+		addProperty(property);
+		return property;
+	}
+
+	/**
+	 * Lookup a group with the given key, or create a new one.
+	 *
+	 * @param key The group's key.
+	 * @return A group with the given key.
+	 * @throws IllegalStateException If a _property_ with the same name exists.
+	 */
+	public Group group(String key) {
+		val entry = children.get(key);
+		if (entry == null) {
+			val group = new Group(key);
+			addGroup(group);
+			return group;
+		} else if (entry instanceof Group) {
+			return (Group) entry;
+		} else {
+			throw new IllegalStateException("A property exists with the same key");
+		}
+	}
+}

--- a/src/main/java/net/clgd/ccemux/config/JsonAdapter.java
+++ b/src/main/java/net/clgd/ccemux/config/JsonAdapter.java
@@ -1,0 +1,107 @@
+package net.clgd.ccemux.config;
+
+import java.util.Map;
+import java.util.Optional;
+
+import com.google.gson.*;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * A serialiser for {@link Config} instances which converts them to and from
+ * {@link JsonElement}s.
+ */
+@Slf4j
+public class JsonAdapter {
+	private static final JsonAdapter instance = new JsonAdapter(
+			new GsonBuilder()
+					.setPrettyPrinting()
+					.setLenient()
+					.create()
+	);
+
+	public static JsonAdapter instance() {
+		return instance;
+	}
+
+	private final Gson gson;
+
+	/**
+	 * Construct a new serialiser with the given {@link Gson} instance.
+	 *
+	 * One may wish to register custom strategies for various property types.
+	 *
+	 * @param gson The finalised instance to use.
+	 */
+	public JsonAdapter(Gson gson) {
+		this.gson = gson;
+	}
+
+	/**
+	 * Convert a config specification to JSON
+	 *
+	 * @param config The specification to convert.
+	 * @return The converted object.
+	 */
+	public JsonElement toJson(Config config) {
+		return toJson(config.getRoot());
+	}
+
+	/**
+	 * Load configuration values from JSON
+	 *
+	 * @param config  The config to load to
+	 * @param element The element to load from.
+	 */
+	public void fromJson(Config config, JsonElement element) {
+		fromJson(config.getRoot(), element);
+	}
+
+	private JsonObject toJson(Group group) {
+		JsonObject object = new JsonObject();
+		for (ConfigEntry entry : group.children()) {
+			if (entry instanceof Property<?>) {
+				Property<?> property = (Property<?>) entry;
+
+				// Don't emit default options
+				if (!property.isDefault() || property.isAlwaysEmit()) {
+					object.add(entry.getKey(), gson.toJsonTree(property.get()));
+				}
+			} else if (entry instanceof Group) {
+				JsonObject element = toJson((Group) entry);
+
+				// Don't emit empty groups
+				if (element.size() > 0) object.add(entry.getKey(), element);
+			}
+		}
+
+		return object;
+	}
+
+	private void fromJson(Group group, JsonElement element) {
+		if (!(element instanceof JsonObject)) {
+			log.error("Expected object for property group {}, got {}", group.getKey(), element);
+			return;
+		}
+
+		JsonObject object = (JsonObject) element;
+		for (Map.Entry<String, JsonElement> jsonEntry : object.entrySet()) {
+			Optional<ConfigEntry> configEntry = group.child(jsonEntry.getKey());
+			if (configEntry.isPresent()) {
+				if (configEntry.get() instanceof Group) {
+					fromJson((Group) configEntry.get(), jsonEntry.getValue());
+				} else if (configEntry.get() instanceof Property<?>) {
+					Property property = (Property<?>) configEntry.get();
+
+					try {
+						//noinspection unchecked
+						property.set(gson.fromJson(jsonEntry.getValue(), property.getType()));
+					} catch (JsonSyntaxException e) {
+						log.error("Cannot parse property '{}' in group '{}' ({})", jsonEntry.getKey(), group.getKey(), e.getMessage());
+					}
+				}
+			} else {
+				log.error("Unknown property '{}' in group '{}'", jsonEntry.getKey(), group.getKey());
+			}
+		}
+	}
+}

--- a/src/main/java/net/clgd/ccemux/config/Property.java
+++ b/src/main/java/net/clgd/ccemux/config/Property.java
@@ -1,0 +1,203 @@
+package net.clgd.ccemux.config;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+
+import com.google.gson.reflect.TypeToken;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import lombok.val;
+
+/**
+ * An entry in a config file which stores a value of the given type.
+ *
+ * @param <T> The type of value to store.
+ */
+@Accessors(chain = true)
+public class Property<T> extends ConfigEntry {
+	private final List<BiConsumer<T, T>> listeners = new ArrayList<>(0);
+
+	@Getter
+	private final String key;
+
+	@Getter
+	@Setter
+	private String name;
+
+	@Setter
+	private String description;
+
+	/**
+	 * The type this property stores. This is likely to be a {@link Class} or
+	 * {@link ParameterizedType}.
+	 */
+	@Getter
+	private final Type type;
+
+	/**
+	 * The default value for this property.
+	 */
+	@Getter
+	private final T defaultValue;
+
+	/**
+	 * Whether this property should always be written to a config file, irrespective
+	 * of whether it's non-default.
+	 *
+	 * @see #isDefault()
+	 */
+	@Getter
+	@Setter
+	private boolean alwaysEmit = false;
+
+	private T value;
+
+	/**
+	 * Whether this property has not been changed, and so stores the default value.
+	 *
+	 * Note that if a property has been changed and happens to have the same value
+	 * as the default then this will be {@code false}. One must call {@link #resetDefault()}
+	 * in order to mark it as default.
+	 */
+	@Getter
+	private boolean isDefault;
+
+	private Property(String key, Type type, T defaultValue) {
+		this.key = key;
+		this.name = key;
+		this.type = type;
+
+		this.defaultValue = defaultValue;
+		this.value = defaultValue;
+		this.isDefault = true;
+	}
+
+	/**
+	 * Create a new property with the given key and add it to the group.
+	 *
+	 * @param key          The property's unique key.
+	 * @param type         The type of this property's value.
+	 * @param defaultValue The default value of this property.
+	 * @throws IllegalStateException If an entry with the same key exists.
+	 * @see Group#property(String, Class, Object)
+	 */
+	public Property(String key, Class<T> type, T defaultValue) {
+		this(key, (Type) type, defaultValue);
+	}
+
+	/**
+	 * Create a new property with the given key and add it to the group.
+	 *
+	 * @param key          The property's unique key.
+	 * @param type         The type of this property's value.
+	 * @param defaultValue The default value of this property.
+	 * @throws IllegalStateException If an entry with the same key exists.
+	 * @see Group#property(String, TypeToken, Object)
+	 */
+	public Property(String key, TypeToken<T> type, T defaultValue) {
+		this(key, type.getType(), defaultValue);
+	}
+
+	/**
+	 * Get the value for this property.
+	 *
+	 * @return This property's value.
+	 */
+	public T get() {
+		return value;
+	}
+
+	/**
+	 * Change the value of this property, marking it as dirty and firing listeners.
+	 *
+	 * @param newValue The value to change the property to.
+	 * @see #resetDefault()
+	 */
+	public void set(T newValue) {
+		set(newValue, false);
+	}
+
+	private void set(T newValue, boolean isDefault) {
+		this.isDefault = isDefault;
+		if (!newValue.equals(value)) {
+			val oldValue = value;
+			value = newValue;
+
+			for (val listener : listeners) listener.accept(oldValue, newValue);
+		}
+	}
+
+	/**
+	 * Reset this property to the default value.
+	 *
+	 * @see #set(Object)
+	 * @see #isDefault()
+	 */
+	public void resetDefault() {
+		set(defaultValue, true);
+	}
+
+	@Override
+	public Optional<String> getDescription() {
+		return Optional.ofNullable(description);
+	}
+
+	/**
+	 * Ensure this property is always written to a config file, irrespective
+	 * of whether it's non-default.
+	 *
+	 * @return The current property.
+	 * @see #isAlwaysEmit()
+	 * @see #setAlwaysEmit(boolean)
+	 */
+	public Property<T> setAlwaysEmit() {
+		return setAlwaysEmit(true);
+	}
+
+	/**
+	 * Add a listener which observes value changes.
+	 *
+	 * @param listener The event listener. This receives the old and new values as arguments.
+	 * @see #addAndFireListener(BiConsumer)
+	 * @see #removeListener(BiConsumer)
+	 */
+	public void addListener(BiConsumer<T, T> listener) {
+		listeners.add(listener);
+	}
+
+	/**
+	 * Add a property change listener and fire it in one go.
+	 *
+	 * This is convenient for syncing properties to an external field.
+	 *
+	 * <pre>
+	 * {@code
+	 * myProperty.addAndFireListener((a, b) -> CustomConfig.myField = b)
+	 * }
+	 * </pre>
+	 *
+	 * @param listener The event listener. This receives the old and new values as arguments.
+	 * @see #addListener(BiConsumer)
+	 * @see #removeListener(BiConsumer)
+	 */
+	public void addAndFireListener(BiConsumer<T, T> listener) {
+		addListener(listener);
+		listener.accept(value, value);
+	}
+
+	/**
+	 * Remove a property change listener
+	 *
+	 * @param listener The event listener to remove.
+	 * @see #addListener(BiConsumer)
+	 * @see #addAndFireListener(BiConsumer)
+	 */
+	public void removeListener(BiConsumer<T, T> listener) {
+		listeners.remove(listener);
+	}
+}

--- a/src/main/java/net/clgd/ccemux/emulation/CCEmuX.java
+++ b/src/main/java/net/clgd/ccemux/emulation/CCEmuX.java
@@ -50,6 +50,9 @@ public class CCEmuX implements Runnable, IComputerEnvironment {
 	private final EmuConfig cfg;
 
 	@Getter
+	private final RendererFactory<?> rendererFactory;
+
+	@Getter
 	private final PluginManager pluginMgr;
 
 	@Getter
@@ -101,7 +104,7 @@ public class CCEmuX implements Runnable, IComputerEnvironment {
 	}
 
 	private void addComputer(EmulatedComputer ec) {
-		Renderer r = RendererFactory.implementations.get(cfg.renderer.get()).create(ec, cfg);
+		Renderer r = rendererFactory.create(ec, cfg);
 
 		ec.addListener(r);
 		r.addListener(() -> this.removeComputer(ec)); // onClose

--- a/src/main/java/net/clgd/ccemux/emulation/EmuConfig.java
+++ b/src/main/java/net/clgd/ccemux/emulation/EmuConfig.java
@@ -24,6 +24,26 @@ public abstract class EmuConfig extends Config {
 			.setName("Terminal width");
 	public Property<String> renderer = property("renderer", String.class, "AWT")
 			.setName("Renderer");
+
 	public Property<Long> maxComputerCapacity = property("maxComputerCapacity", Long.class, 2L * 1024 * 1024)
 			.setName("Max computer capacity");
+	public Property<Boolean> httpEnabled = property("httpEnable", Boolean.class, true)
+			.setName("Enable HTTP API")
+			.setDescription("Enable the \"http\" API on Computers (see \"httpWhitelist\" and \"httpBlacklist\" for more fine grained control than this)");
+	public Property<String[]> httpWhitelist = property("httpWhitelist", String[].class, new String[]{"*"})
+			.setName("HTTP whitelist")
+			.setDescription("A list of wildcards for domains or IP ranges that can be accessed through the \"http\" API on Computers.\n" +
+					"Set this to \"*\" to access to the entire internet. Example: \"*.pastebin.com\" will restrict access to just subdomains of pastebin.com.\n" +
+					"You can use domain names (\"pastebin.com\"), wilcards (\"*.pastebin.com\") or CIDR notation (\"127.0.0.0/8\").");
+	public Property<String[]> httpBlacklist = property("httpBlacklist", String[].class, new String[]{"127.0.0.0/8", "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "fd00::/8"})
+			.setName("HTTP blacklist")
+			.setDescription("A list of wildcards for domains or IP ranges that cannot be accessed through the \"http\" API on Computers.\n" +
+					"If this is empty then all whitelisted domains will be accessible. Example: \"*.github.com\" will block access to all subdomains of github.com.\n" +
+					"You can use domain names (\"pastebin.com\"), wilcards (\"*.pastebin.com\") or CIDR notation (\"127.0.0.0/8\").");
+	public Property<Boolean> disableLua51Features = property("disableLua51Features", Boolean.class, false)
+			.setName("Disable Lua 5.1 features")
+			.setDescription("Set this to true to disable Lua 5.1 functions that will be removed in a future update. Useful for ensuring forward compatibility of your programs now.");
+	public Property<String> defaultComputerSettings = property("defaultComputerSettings", String.class, "")
+			.setName("Default computer settings")
+			.setDescription("A comma seperated list of default system settings to set on new computers. Example: \"shell.autocomplete=false,lua.autocomplete=false,edit.autocomplete=false\" will disable all autocompletion");
 }

--- a/src/main/java/net/clgd/ccemux/emulation/EmuConfig.java
+++ b/src/main/java/net/clgd/ccemux/emulation/EmuConfig.java
@@ -1,28 +1,29 @@
 package net.clgd.ccemux.emulation;
 
 import java.nio.file.Path;
-import java.util.Map;
 
 import com.google.gson.Gson;
-import com.google.gson.JsonElement;
-
 import net.clgd.ccemux.config.Config;
-import net.clgd.ccemux.plugins.Plugin;
+import net.clgd.ccemux.config.JsonAdapter;
+import net.clgd.ccemux.config.Property;
 
 public abstract class EmuConfig extends Config {
-	public EmuConfig(Gson gson, Map<String, JsonElement> data) {
-		super(gson, data);
-	}
-	
-	public abstract Path getDataDir();
-	
-	public Property<Double> termScale = property("termScale", Double.class, 2.0);
-	public Property<Integer> termHeight = property("termHeight", Integer.class, 19);
-	public Property<Integer> termWidth = property("termWidth", Integer.class, 52);
-	public Property<String> renderer = property("renderer", String.class, "AWT");
-	public Property<Long> maxComputerCapacity = property("maxComputerCapacity", Long.class, 2L * 1024 * 1024);
+	protected final JsonAdapter adapter;
 
-	public Property<Boolean> pluginEnabled(Plugin plugin) {
-		return property("plugin." + plugin.getClass().getName() + ".enabled", Boolean.class, true);
+	public EmuConfig(Gson gson) {
+		adapter = new JsonAdapter(gson);
 	}
+
+	public abstract Path getDataDir();
+
+	public Property<Double> termScale = property("termScale", Double.class, 2.0)
+			.setName("Terminal scale");
+	public Property<Integer> termHeight = property("termHeight", Integer.class, 19)
+			.setName("Terminal height");
+	public Property<Integer> termWidth = property("termWidth", Integer.class, 52)
+			.setName("Terminal width");
+	public Property<String> renderer = property("renderer", String.class, "AWT")
+			.setName("Renderer");
+	public Property<Long> maxComputerCapacity = property("maxComputerCapacity", Long.class, 2L * 1024 * 1024)
+			.setName("Max computer capacity");
 }

--- a/src/main/java/net/clgd/ccemux/emulation/EmuConfig.java
+++ b/src/main/java/net/clgd/ccemux/emulation/EmuConfig.java
@@ -1,5 +1,6 @@
 package net.clgd.ccemux.emulation;
 
+import java.io.IOException;
 import java.nio.file.Path;
 
 import com.google.gson.Gson;
@@ -11,7 +12,7 @@ public abstract class EmuConfig extends Config {
 	protected final JsonAdapter adapter;
 
 	public EmuConfig(Gson gson) {
-		adapter = new JsonAdapter(gson);
+		adapter = new JsonAdapter(gson, this);
 	}
 
 	public abstract Path getDataDir();
@@ -46,4 +47,8 @@ public abstract class EmuConfig extends Config {
 	public Property<String> defaultComputerSettings = property("defaultComputerSettings", String.class, "")
 			.setName("Default computer settings")
 			.setDescription("A comma seperated list of default system settings to set on new computers. Example: \"shell.autocomplete=false,lua.autocomplete=false,edit.autocomplete=false\" will disable all autocompletion");
+
+	public abstract void save() throws IOException;
+
+	public abstract void load() throws IOException;
 }

--- a/src/main/java/net/clgd/ccemux/init/Launcher.java
+++ b/src/main/java/net/clgd/ccemux/init/Launcher.java
@@ -217,6 +217,7 @@ public class Launcher {
 			PluginManager pluginMgr = new PluginManager(cfg);
 			pluginMgr.gatherCandidates(buildLoader());
 			cfg.load();
+			cfg.saveDefault();
 			pluginMgr.gatherEnabled();
 
 			pluginMgr.loaderSetup(getClass().getClassLoader());

--- a/src/main/java/net/clgd/ccemux/init/Launcher.java
+++ b/src/main/java/net/clgd/ccemux/init/Launcher.java
@@ -253,7 +253,8 @@ public class Launcher {
 				// TODO: figure out this
 			}
 
-			if (!RendererFactory.implementations.containsKey(cfg.renderer.get())) {
+			RendererFactory renderFactory = RendererFactory.implementations.get(cfg.renderer.get());
+			if (renderFactory == null) {
 				log.error("Specified renderer '{}' does not exist - are you missing a plugin?", cfg.renderer.get());
 
 				if (!GraphicsEnvironment.isHeadless()) {
@@ -262,6 +263,8 @@ public class Launcher {
 									+ "Please double check your config file and plugin list.",
 							"Configuration Error", JOptionPane.ERROR_MESSAGE);
 				}
+
+				System.exit(1);
 			}
 
 			pluginMgr.onInitializationCompleted();
@@ -273,7 +276,7 @@ public class Launcher {
 
 			TerminalFonts.loadImplicitFonts();
 
-			CCEmuX emu = new CCEmuX(cfg, pluginMgr, getCCSource());
+			CCEmuX emu = new CCEmuX(cfg, renderFactory, pluginMgr, getCCSource());
 			emu.createComputer();
 			emu.run();
 

--- a/src/main/java/net/clgd/ccemux/init/Launcher.java
+++ b/src/main/java/net/clgd/ccemux/init/Launcher.java
@@ -25,6 +25,7 @@ import org.apache.commons.cli.Options;
 import org.apache.logging.log4j.LogManager;
 
 import dan200.computercraft.ComputerCraft;
+import dan200.computercraft.core.apis.AddressPredicate;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import net.clgd.ccemux.OperatingSystem;
@@ -65,15 +66,14 @@ public class Launcher {
 		} else {
 			try (final CCEmuXClassloader loader = new CCEmuXClassloader(
 					((URLClassLoader) Launcher.class.getClassLoader()).getURLs())) {
-				@SuppressWarnings("unchecked")
-				final Class<Launcher> klass = (Class<Launcher>) loader.findClass(Launcher.class.getName());
+				@SuppressWarnings("unchecked") final Class<Launcher> klass = (Class<Launcher>) loader.findClass(Launcher.class.getName());
 
 				final Constructor<Launcher> constructor = klass.getDeclaredConstructor(String[].class);
 				constructor.setAccessible(true);
 
 				final Method launch = klass.getDeclaredMethod("launch");
 				launch.setAccessible(true);
-				launch.invoke(constructor.newInstance(new Object[] { args }));
+				launch.invoke(constructor.newInstance(new Object[]{args}));
 			} catch (Exception e) {
 				log.warn("Failed to setup rewriting classloader - some features may be unavailable", e);
 				new Launcher(args).launch();
@@ -130,8 +130,8 @@ public class Launcher {
 			scrollPane.setMaximumSize(new Dimension(600, 400));
 
 			int result = JOptionPane.showConfirmDialog(null,
-					new Object[] { "CCEmuX has crashed!", scrollPane,
-							"Would you like to create a bug report on GitHub?" },
+					new Object[]{"CCEmuX has crashed!", scrollPane,
+							"Would you like to create a bug report on GitHub?"},
 					"CCEmuX Crash", JOptionPane.YES_NO_OPTION, JOptionPane.ERROR_MESSAGE);
 
 			if (result == JOptionPane.YES_OPTION) {
@@ -232,6 +232,15 @@ public class Launcher {
 			}
 
 			ComputerCraft.log = LogManager.getLogger(ComputerCraft.class);
+
+			// Setup the properties to sync with the original.
+			// computerSpaceLimit isn't technically needed, but we do it for consistency's sake.
+			cfg.maxComputerCapacity.addAndFireListener((o, n) -> ComputerCraft.computerSpaceLimit = n.intValue());
+			cfg.httpEnabled.addAndFireListener((o, n) -> ComputerCraft.http_enable = n);
+			cfg.httpWhitelist.addAndFireListener((o, n) -> ComputerCraft.http_whitelist = new AddressPredicate(n));
+			cfg.httpBlacklist.addAndFireListener((o, n) -> ComputerCraft.http_blacklist = new AddressPredicate(n));
+			cfg.disableLua51Features.addAndFireListener((o, n) -> ComputerCraft.disable_lua51_features = n);
+			cfg.defaultComputerSettings.addAndFireListener((o, n) -> ComputerCraft.default_computer_settings = n);
 
 			pluginMgr.setup();
 

--- a/src/main/java/net/clgd/ccemux/init/Launcher.java
+++ b/src/main/java/net/clgd/ccemux/init/Launcher.java
@@ -208,7 +208,7 @@ public class Launcher {
 			Files.createDirectories(dataDir);
 
 			log.info("Loading user config");
-			UserConfig cfg = UserConfig.loadConfig(dataDir);
+			UserConfig cfg = new UserConfig(dataDir);
 			log.debug("Config: {}", cfg);
 
 			if (cfg.termScale.get() != cfg.termScale.get().intValue())
@@ -216,7 +216,7 @@ public class Launcher {
 
 			PluginManager pluginMgr = new PluginManager(cfg);
 			pluginMgr.gatherCandidates(buildLoader());
-			cfg.loadConfig();
+			cfg.load();
 			pluginMgr.gatherEnabled();
 
 			pluginMgr.loaderSetup(getClass().getClassLoader());

--- a/src/main/java/net/clgd/ccemux/init/UserConfig.java
+++ b/src/main/java/net/clgd/ccemux/init/UserConfig.java
@@ -30,6 +30,7 @@ public class UserConfig extends EmuConfig {
 	private UserConfig(Path dataDir) {
 		super(gson);
 		this.dataDir = dataDir;
+		getRoot().setName("CCEmuX Config");
 	}
 
 	public void loadConfig() throws IOException {

--- a/src/main/java/net/clgd/ccemux/init/UserConfig.java
+++ b/src/main/java/net/clgd/ccemux/init/UserConfig.java
@@ -20,28 +20,24 @@ public class UserConfig extends EmuConfig {
 
 	private static final Gson gson = new GsonBuilder().setPrettyPrinting().create();
 
-	public static UserConfig loadConfig(Path dataDir) throws IOException {
-		return new UserConfig(dataDir);
-	}
-
 	@Getter
 	private final Path dataDir;
 
-	private UserConfig(Path dataDir) {
+	public UserConfig(Path dataDir) {
 		super(gson);
 		this.dataDir = dataDir;
 		getRoot().setName("CCEmuX Config");
 	}
 
-	public void loadConfig() throws IOException {
+	public void load() throws IOException {
 		try (Reader reader = Files.newBufferedReader(dataDir.resolve(CONFIG_FILE_NAME), StandardCharsets.UTF_8)) {
-			adapter.fromJson(this, gson.fromJson(reader, JsonElement.class));
+			adapter.fromJson(gson.fromJson(reader, JsonElement.class));
 		}
 	}
 
-	public void saveConfig() throws IOException {
+	public void save() throws IOException {
 		try (Writer writer = Files.newBufferedWriter(dataDir.resolve(CONFIG_FILE_NAME), StandardCharsets.UTF_8)) {
-			gson.toJson(adapter.toJson(this), writer);
+			gson.toJson(adapter.toJson(), writer);
 		}
 	}
 }

--- a/src/main/java/net/clgd/ccemux/init/UserConfig.java
+++ b/src/main/java/net/clgd/ccemux/init/UserConfig.java
@@ -7,9 +7,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonElement;
+import com.google.gson.*;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import net.clgd.ccemux.emulation.EmuConfig;
@@ -17,6 +15,8 @@ import net.clgd.ccemux.emulation.EmuConfig;
 @EqualsAndHashCode(callSuper = true)
 public class UserConfig extends EmuConfig {
 	public static final String CONFIG_FILE_NAME = "ccemux.json";
+
+	public static final String DEFAULT_FILE_NAME = "ccemux.default.json";
 
 	private static final Gson gson = new GsonBuilder().setPrettyPrinting().create();
 
@@ -30,14 +30,28 @@ public class UserConfig extends EmuConfig {
 	}
 
 	public void load() throws IOException {
-		try (Reader reader = Files.newBufferedReader(dataDir.resolve(CONFIG_FILE_NAME), StandardCharsets.UTF_8)) {
-			adapter.fromJson(gson.fromJson(reader, JsonElement.class));
+		Path configPath = dataDir.resolve(CONFIG_FILE_NAME);
+		if (Files.exists(configPath)) {
+			try (Reader reader = Files.newBufferedReader(configPath, StandardCharsets.UTF_8)) {
+				adapter.fromJson(gson.fromJson(reader, JsonElement.class));
+			}
+		} else {
+			JsonObject elements = new JsonObject();
+			elements.add("_comment", new JsonPrimitive("This is the config file for CCEmuX. Refer to ccemux.default.json for the various options."));
+			adapter.fromJson(elements);
+			save();
 		}
 	}
 
 	public void save() throws IOException {
 		try (Writer writer = Files.newBufferedWriter(dataDir.resolve(CONFIG_FILE_NAME), StandardCharsets.UTF_8)) {
 			gson.toJson(adapter.toJson(), writer);
+		}
+	}
+
+	public void saveDefault() throws IOException {
+		try (Writer writer = Files.newBufferedWriter(dataDir.resolve(DEFAULT_FILE_NAME), StandardCharsets.UTF_8)) {
+			gson.toJson(adapter.toDefaultJson(), writer);
 		}
 	}
 }

--- a/src/main/java/net/clgd/ccemux/plugins/Plugin.java
+++ b/src/main/java/net/clgd/ccemux/plugins/Plugin.java
@@ -6,6 +6,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
+import net.clgd.ccemux.config.Group;
 import net.clgd.ccemux.emulation.EmuConfig;
 import net.clgd.ccemux.plugins.hooks.Hook;
 
@@ -33,8 +34,7 @@ public abstract class Plugin {
 	/**
 	 * Gets all the hooks this plugin has registered of a specific type
 	 *
-	 * @param cls
-	 *            The type
+	 * @param cls The type
 	 * @return
 	 */
 	@SuppressWarnings("unchecked")
@@ -60,15 +60,12 @@ public abstract class Plugin {
 	 * <br />
 	 *
 	 * @deprecated Using this method with lambdas as opposed to
-	 *             {@link #registerHook(Hook)} with anonymous classes may cause
-	 *             crashes, as lambdas force the JVM to load classes earlier
-	 *             than usual, which can result in a
-	 *             {@link ClassNotFoundException} because of the way
-	 *             ComputerCraft is loaded at runtime. This method will most
-	 *             likely be removed in the future.
-	 *
-	 * @see Hook
-	 * @see #registerHook(Hook)
+	 * {@link #registerHook(Hook)} with anonymous classes may cause
+	 * crashes, as lambdas force the JVM to load classes earlier
+	 * than usual, which can result in a
+	 * {@link ClassNotFoundException} because of the way
+	 * ComputerCraft is loaded at runtime. This method will most
+	 * likely be removed in the future.
 	 */
 	@Deprecated
 	protected final <T extends Hook> void registerHook(Class<T> cls, T hook) {
@@ -102,9 +99,18 @@ public abstract class Plugin {
 	 * wiki, source code, or anything else that may be helpful to end-users. If
 	 * an empty <code>Optional</code> is returned, no website will be shown to
 	 * end-users.
-	 *
 	 */
 	public abstract Optional<String> getWebsite();
+
+	/**
+	 * Setup any configuration options this plugin requires.
+	 *
+	 * This is called before anything else is loaded, and so one should be careful
+	 * not to reference any CC classes.
+	 *
+	 * @param group The group to load config elements from.
+	 */
+	public void configSetup(Group group) {}
 
 	/**
 	 * Called early while CCEmuX is starting, before even CC itself is loaded.
@@ -112,14 +118,15 @@ public abstract class Plugin {
 	 * before CC is loaded and should not be used unless you know what you're
 	 * doing!
 	 *
-	 * @see #setup()
+	 * @see #setup(EmuConfig)
+	 * @see #configSetup(Group)
 	 */
-	public void loaderSetup(EmuConfig cfg, ClassLoader loader) {};
+	public void loaderSetup(EmuConfig cfg, ClassLoader loader) {}
 
 	/**
 	 * Called while CCEmuX is starting. This method should be used to register
-	 * hooks, or renderers.<br />
-	 * <br />
+	 * hooks, or renderers.
+	 *
 	 * In order to prevent issues, any setup code that needs to interact with CC
 	 * should use the
 	 * {@link net.clgd.ccemux.plugins.hooks.InitializationCompleted

--- a/src/main/java/net/clgd/ccemux/plugins/PluginManager.java
+++ b/src/main/java/net/clgd/ccemux/plugins/PluginManager.java
@@ -63,8 +63,6 @@ public class PluginManager implements Closing, CreatingComputer, CreatingROM, Co
 	public void gatherEnabled() {
 		for (PluginCandidate candidate : candidates) {
 			val source = candidate.plugin.getSource().map(File::getAbsolutePath).orElse("(unknown)");
-			log.debug("Found plugin [{}] from {}", candidate, source);
-
 			if (candidate.enabled.get()) {
 				enabled.add(candidate.plugin);
 				log.info("Loaded plugin [{}] from {}", candidate.plugin, source);

--- a/src/main/java/net/clgd/ccemux/plugins/PluginManager.java
+++ b/src/main/java/net/clgd/ccemux/plugins/PluginManager.java
@@ -51,9 +51,7 @@ public class PluginManager implements Closing, CreatingComputer, CreatingROM, Co
 
 			candidates.add(new PluginCandidate(
 					candidate,
-					cfgCandidate.property("enabled", Boolean.class, true)
-							.setName("Enabled")
-							.setAlwaysEmit()
+					cfgCandidate.property("enabled", Boolean.class, true).setName("Enabled")
 			));
 
 			candidate.configSetup(cfgCandidate);

--- a/src/main/java/net/clgd/ccemux/plugins/builtin/AWTPlugin.java
+++ b/src/main/java/net/clgd/ccemux/plugins/builtin/AWTPlugin.java
@@ -1,16 +1,20 @@
 package net.clgd.ccemux.plugins.builtin;
 
+import java.lang.ref.WeakReference;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
-import java.util.Set;
+
+import javax.swing.JFrame;
 
 import com.google.auto.service.AutoService;
-
 import net.clgd.ccemux.emulation.EmuConfig;
+import net.clgd.ccemux.emulation.EmulatedComputer;
 import net.clgd.ccemux.plugins.Plugin;
+import net.clgd.ccemux.rendering.Renderer;
 import net.clgd.ccemux.rendering.RendererFactory;
 import net.clgd.ccemux.rendering.awt.AWTRenderer;
+import net.clgd.ccemux.rendering.awt.config.ConfigView;
 
 @AutoService(Plugin.class)
 public class AWTPlugin extends Plugin {
@@ -41,6 +45,30 @@ public class AWTPlugin extends Plugin {
 
 	@Override
 	public void setup(EmuConfig cfg) {
-		RendererFactory.implementations.put("AWT", AWTRenderer::new);
+		RendererFactory.implementations.put("AWT", new RendererFactory<Renderer>() {
+			private WeakReference<JFrame> lastFrame = null;
+
+			@Override
+			public Renderer create(EmulatedComputer computer, EmuConfig cfg) {
+				return new AWTRenderer(computer, cfg);
+			}
+
+			@Override
+			public synchronized boolean createConfigEditor(EmuConfig config) {
+				if (lastFrame != null) {
+					JFrame frame = lastFrame.get();
+					if (frame != null && frame.isVisible()) {
+						frame.toFront();
+						return true;
+					}
+				}
+
+				JFrame newFrame = new ConfigView(config);
+				newFrame.setVisible(true);
+				lastFrame = new WeakReference<>(newFrame);
+
+				return true;
+			}
+		});
 	}
 }

--- a/src/main/java/net/clgd/ccemux/plugins/builtin/CCEmuXAPI.java
+++ b/src/main/java/net/clgd/ccemux/plugins/builtin/CCEmuXAPI.java
@@ -11,12 +11,13 @@ import java.util.*;
 import org.apache.commons.io.IOUtils;
 
 import com.google.auto.service.AutoService;
-
 import dan200.computercraft.api.lua.ILuaContext;
 import dan200.computercraft.api.lua.LuaException;
 import dan200.computercraft.core.apis.ILuaAPI;
 import lombok.extern.slf4j.Slf4j;
-import net.clgd.ccemux.emulation.*;
+import net.clgd.ccemux.emulation.CCEmuX;
+import net.clgd.ccemux.emulation.EmuConfig;
+import net.clgd.ccemux.emulation.EmulatedComputer;
 import net.clgd.ccemux.emulation.filesystem.VirtualDirectory.Builder;
 import net.clgd.ccemux.emulation.filesystem.VirtualFile;
 import net.clgd.ccemux.plugins.Plugin;
@@ -96,6 +97,14 @@ public class CCEmuXAPI extends Plugin {
 				}
 
 				return new Object[] {};
+			});
+
+			methods.put("openConfig", o -> {
+				if (emu.getRendererFactory().createConfigEditor(emu.getCfg())) {
+					return new Object[]{true};
+				} else {
+					return new Object[]{false, "Not supported with this renderer"};
+				}
 			});
 		}
 

--- a/src/main/java/net/clgd/ccemux/plugins/builtin/CCTweaksPlugin.java
+++ b/src/main/java/net/clgd/ccemux/plugins/builtin/CCTweaksPlugin.java
@@ -3,8 +3,8 @@ package net.clgd.ccemux.plugins.builtin;
 import java.awt.GraphicsEnvironment;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 import javax.swing.JOptionPane;
 
@@ -13,14 +13,20 @@ import org.squiddev.cctweaks.lua.launch.RewritingLoader;
 import org.squiddev.cctweaks.lua.lib.ApiRegister;
 
 import com.google.auto.service.AutoService;
-
+import com.google.gson.JsonPrimitive;
+import com.google.gson.reflect.TypeToken;
 import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import net.clgd.ccemux.config.Group;
+import net.clgd.ccemux.config.Property;
 import net.clgd.ccemux.emulation.EmuConfig;
 import net.clgd.ccemux.plugins.Plugin;
 
 @Slf4j
 @AutoService(Plugin.class)
 public class CCTweaksPlugin extends Plugin {
+	private Property<Map<String, JsonPrimitive>> options;
+
 	@Override
 	public String getName() {
 		return "CCTweaks";
@@ -46,14 +52,22 @@ public class CCTweaksPlugin extends Plugin {
 		return Optional.of("https://github.com/SquidDev-CC/CCTweaks-Lua");
 	}
 
-	private void applyConfig(EmuConfig cfg) {
-		cfg.keys().stream().filter(k -> k.startsWith("cctweaks."))
-				.forEach(k -> System.setProperty(k, cfg.getAs(k, String.class).get()));
+	@Override
+	public void configSetup(Group group) {
+		options = group.property("options", new TypeToken<Map<String, JsonPrimitive>>() {}, Collections.emptyMap())
+				.setName("Options")
+				.setDescription("Key-value configuration options to be passed to CCTweaks");
+	}
+
+	private void syncConfig() {
+		for (val option : options.get().entrySet()) {
+			System.setProperty("cctweaks." + option.getKey(), option.getValue().getAsString());
+		}
 	}
 
 	@Override
 	public void loaderSetup(EmuConfig cfg, ClassLoader loader) {
-		applyConfig(cfg);
+		syncConfig();
 
 		if (loader instanceof RewritingLoader) {
 
@@ -85,6 +99,14 @@ public class CCTweaksPlugin extends Plugin {
 				log.warn("Failed to apply classloader tweaks", e);
 			}
 
+			options.addListener((x, y) -> {
+				syncConfig();
+				try {
+					rwLoader.loadConfig();
+				} catch (Exception e) {
+					log.warn("Failed to refresh config", e);
+				}
+			});
 		} else {
 			log.warn("Incompatible ClassLoader in use - CCTweaks functionality unavailable");
 

--- a/src/main/java/net/clgd/ccemux/rendering/RendererFactory.java
+++ b/src/main/java/net/clgd/ccemux/rendering/RendererFactory.java
@@ -9,6 +9,10 @@ import net.clgd.ccemux.emulation.EmulatedComputer;
 @FunctionalInterface
 public interface RendererFactory<T extends Renderer> {
 	public static final Map<String, RendererFactory<?>> implementations = new HashMap<>();
-	
+
 	public T create(EmulatedComputer computer, EmuConfig cfg);
+
+	default boolean createConfigEditor(EmuConfig config) {
+		return false;
+	}
 }

--- a/src/main/java/net/clgd/ccemux/rendering/awt/AWTRenderer.java
+++ b/src/main/java/net/clgd/ccemux/rendering/awt/AWTRenderer.java
@@ -30,7 +30,6 @@ import net.clgd.ccemux.emulation.EmulatedComputer;
 import net.clgd.ccemux.rendering.Renderer;
 import net.clgd.ccemux.rendering.TerminalFont;
 import net.clgd.ccemux.rendering.TerminalFonts;
-import net.clgd.ccemux.rendering.awt.config.ConfigView;
 
 @Slf4j
 public class AWTRenderer
@@ -91,7 +90,6 @@ public class AWTRenderer
 
 		frame.setLayout(new BorderLayout());
 
-		new ConfigView(config).setVisible(true);
 		// setMinimumSize(new Dimension(300, 200));
 
 		termComponent = new TerminalComponent(computer.terminal, config.termScale.get());

--- a/src/main/java/net/clgd/ccemux/rendering/awt/AWTRenderer.java
+++ b/src/main/java/net/clgd/ccemux/rendering/awt/AWTRenderer.java
@@ -20,8 +20,6 @@ import java.util.List;
 import javax.imageio.ImageIO;
 import javax.swing.JOptionPane;
 
-import net.clgd.ccemux.rendering.TerminalFont;
-import net.clgd.ccemux.rendering.TerminalFonts;
 import org.apache.commons.io.IOUtils;
 
 import lombok.extern.slf4j.Slf4j;
@@ -30,6 +28,9 @@ import net.clgd.ccemux.emulation.CCEmuX;
 import net.clgd.ccemux.emulation.EmuConfig;
 import net.clgd.ccemux.emulation.EmulatedComputer;
 import net.clgd.ccemux.rendering.Renderer;
+import net.clgd.ccemux.rendering.TerminalFont;
+import net.clgd.ccemux.rendering.TerminalFonts;
+import net.clgd.ccemux.rendering.awt.config.ConfigView;
 
 @Slf4j
 public class AWTRenderer
@@ -89,6 +90,8 @@ public class AWTRenderer
 		pixelHeight = (int) (9 * config.termScale.get());
 
 		frame.setLayout(new BorderLayout());
+
+		new ConfigView(config).setVisible(true);
 		// setMinimumSize(new Dimension(300, 200));
 
 		termComponent = new TerminalComponent(computer.terminal, config.termScale.get());

--- a/src/main/java/net/clgd/ccemux/rendering/awt/config/CollectionPropertyComponent.java
+++ b/src/main/java/net/clgd/ccemux/rendering/awt/config/CollectionPropertyComponent.java
@@ -1,0 +1,88 @@
+package net.clgd.ccemux.rendering.awt.config;
+
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JPanel;
+
+import lombok.val;
+
+public abstract class CollectionPropertyComponent<T, TEntry extends CollectionPropertyEntry> extends JComponent {
+	private static final long serialVersionUID = 2221453079243528113L;
+
+	private final List<TEntry> entries;
+	private final Consumer<T> valueChanged;
+
+	protected final JPanel components;
+	private final GridBagLayout layout;
+
+	public CollectionPropertyComponent(Consumer<T> valueChanged) {
+		this.entries = new ArrayList<>();
+		this.valueChanged = valueChanged;
+
+		setLayout(new GridBagLayout());
+
+		// We create a child grid view as otherwise the add button
+		// gets all messed up when moving elements around.
+		{
+			val constraints = new GridBagConstraints();
+			constraints.gridx = 0;
+			constraints.gridy = 0;
+			constraints.weightx = 1;
+			constraints.weighty = 1;
+			constraints.fill = GridBagConstraints.BOTH;
+
+			components = new JPanel(layout = new GridBagLayout());
+			SwingHelpers.hideBackground(components);
+			add(components, constraints);
+		}
+
+		{
+			val constraints = new GridBagConstraints();
+			constraints.gridx = 0;
+			constraints.gridy = 1;
+			constraints.insets = SwingHelpers.SMALL_PADDING;
+			constraints.fill = GridBagConstraints.HORIZONTAL;
+
+			val addButton = new JButton("Add");
+			addButton.setToolTipText("Add a new entry");
+			addButton.addActionListener(e -> {
+				addEntry(createBlank());
+				valueChanged();
+				components.revalidate();
+				components.repaint();
+			});
+			add(addButton, constraints);
+		}
+	}
+
+	protected abstract TEntry createBlank();
+
+	protected abstract T toValue(List<TEntry> rows);
+
+	protected void addEntry(TEntry entry) {
+		entry.setRow(entries.size());
+		entries.add(entry);
+	}
+
+	protected void removeEntry(TEntry entry) {
+		int index = entries.indexOf(entry);
+		if (index < 0) return;
+
+		// Remove this entry
+		entries.remove(index);
+		valueChanged();
+
+		// And shift all other elements up
+		for (int i = index; i < entries.size(); i++) entries.get(i).setRow(i);
+	}
+
+	protected void valueChanged() {
+		valueChanged.accept(toValue(entries));
+	}
+}

--- a/src/main/java/net/clgd/ccemux/rendering/awt/config/CollectionPropertyEntry.java
+++ b/src/main/java/net/clgd/ccemux/rendering/awt/config/CollectionPropertyEntry.java
@@ -1,0 +1,10 @@
+package net.clgd.ccemux.rendering.awt.config;
+
+public interface CollectionPropertyEntry {
+	/**
+	 * Set the row this collection entry exists in
+	 *
+	 * @param row The collection entry's row
+	 */
+	void setRow(int row);
+}

--- a/src/main/java/net/clgd/ccemux/rendering/awt/config/ConfigView.java
+++ b/src/main/java/net/clgd/ccemux/rendering/awt/config/ConfigView.java
@@ -3,6 +3,7 @@ package net.clgd.ccemux.rendering.awt.config;
 import java.awt.*;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
+import java.io.IOException;
 
 import javax.swing.*;
 import javax.swing.border.EmptyBorder;
@@ -13,10 +14,11 @@ import javax.swing.tree.TreeModel;
 import javax.swing.tree.TreePath;
 
 import lombok.val;
-import net.clgd.ccemux.config.Config;
 import net.clgd.ccemux.config.ConfigEntry;
 import net.clgd.ccemux.config.Group;
 import net.clgd.ccemux.config.Property;
+import net.clgd.ccemux.emulation.EmuConfig;
+import net.clgd.ccemux.init.UserConfig;
 
 public class ConfigView extends JFrame {
 	private static final long serialVersionUID = 5150153551199976130L;
@@ -26,7 +28,7 @@ public class ConfigView extends JFrame {
 	private final JLabel currentGroup;
 	private final JTree tree;
 
-	public ConfigView(Config config) {
+	public ConfigView(EmuConfig config) {
 		setLayout(new BorderLayout());
 		setMinimumSize(new Dimension(400, 200));
 		setSize(new Dimension(600, 300));
@@ -108,7 +110,16 @@ public class ConfigView extends JFrame {
 
 		addWindowListener(new WindowAdapter() {
 			@Override
-			public void windowClosing(WindowEvent e) {
+			public void windowClosing(WindowEvent event) {
+				// TODO: Make this actually nice.
+				if (config instanceof UserConfig) try {
+					config.save();
+				} catch (IOException e) {
+					JOptionPane.showMessageDialog(ConfigView.this,
+							"Cannot save config file: " + e.getMessage(),
+							"Error saving config", JOptionPane.ERROR_MESSAGE);
+				}
+
 				dispose();
 			}
 		});

--- a/src/main/java/net/clgd/ccemux/rendering/awt/config/ConfigView.java
+++ b/src/main/java/net/clgd/ccemux/rendering/awt/config/ConfigView.java
@@ -108,18 +108,21 @@ public class ConfigView extends JFrame {
 
 		pushGroup(config.getRoot());
 
+		setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
 		addWindowListener(new WindowAdapter() {
 			@Override
 			public void windowClosing(WindowEvent event) {
-				// TODO: Make this actually nice.
-				if (config instanceof UserConfig) try {
-					config.save();
-				} catch (IOException e) {
-					JOptionPane.showMessageDialog(ConfigView.this,
-							"Cannot save config file: " + e.getMessage(),
-							"Error saving config", JOptionPane.ERROR_MESSAGE);
+				if (config instanceof UserConfig) {
+					try {
+						config.save();
+					} catch (IOException e) {
+						JOptionPane.showMessageDialog(ConfigView.this,
+								"Cannot save config file: " + e.getMessage(),
+								"Error saving config", JOptionPane.ERROR_MESSAGE);
+					}
 				}
 
+				setVisible(false);
 				dispose();
 			}
 		});

--- a/src/main/java/net/clgd/ccemux/rendering/awt/config/ConfigView.java
+++ b/src/main/java/net/clgd/ccemux/rendering/awt/config/ConfigView.java
@@ -1,0 +1,169 @@
+package net.clgd.ccemux.rendering.awt.config;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+import javax.swing.*;
+
+import lombok.val;
+import net.clgd.ccemux.config.Config;
+import net.clgd.ccemux.config.Group;
+import net.clgd.ccemux.config.Property;
+
+public class ConfigView extends JFrame {
+	private static final long serialVersionUID = 5150153551199976130L;
+
+	private final Deque<Group> history = new ArrayDeque<>();
+	private final JPanel scrollBody;
+	private final JButton backButton;
+	private final JLabel currentGroup;
+
+	public ConfigView(Config config) {
+		setLayout(new GridBagLayout());
+		setMinimumSize(new Dimension(400, 200));
+		setSize(new Dimension(600, 300));
+		setTitle("Config");
+		setBackground(Color.WHITE);
+
+		{
+			backButton = new JButton("Back");
+			backButton.setEnabled(false);
+			backButton.addActionListener(e -> popGroup());
+
+			GridBagConstraints constraints = new GridBagConstraints();
+			constraints.gridx = 0;
+			constraints.gridy = 0;
+			constraints.insets = SwingHelpers.PADDING;
+			constraints.fill = GridBagConstraints.BOTH;
+
+			add(backButton, constraints);
+		}
+
+		{
+			GridBagConstraints constraints = new GridBagConstraints();
+			constraints.gridx = 1;
+			constraints.gridy = 0;
+			constraints.weightx = 1;
+			constraints.insets = SwingHelpers.PADDING;
+			constraints.fill = GridBagConstraints.BOTH;
+
+			currentGroup = new JLabel("");
+			add(currentGroup, constraints);
+		}
+
+		{
+			GridBagConstraints constraints = new GridBagConstraints();
+			constraints.gridx = 0;
+			constraints.gridy = 1;
+			constraints.gridwidth = 2;
+			constraints.weighty = 1;
+			constraints.insets = SwingHelpers.PADDING;
+			constraints.fill = GridBagConstraints.BOTH;
+
+			JScrollPane scroll = new JScrollPane();
+			scroll.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
+			SwingHelpers.hideBackground(scroll);
+			SwingHelpers.hideBackground(scroll.getViewport());
+			add(scroll, constraints);
+
+
+			scrollBody = new JPanel(new GridBagLayout());
+			SwingHelpers.hideBackground(scrollBody);
+			scroll.getViewport().add(scrollBody);
+		}
+
+		pushGroup(config.getRoot());
+
+		addWindowListener(new WindowAdapter() {
+			@Override
+			public void windowClosing(WindowEvent e) {
+				dispose();
+			}
+		});
+	}
+
+	private void pushGroup(Group group) {
+		history.push(group);
+		loadGroup(group);
+	}
+
+	private void popGroup() {
+		if (history.size() > 1) {
+			history.pop();
+			loadGroup(history.peek());
+		}
+	}
+
+	private void loadGroup(Group configGroup) {
+		backButton.setEnabled(history.size() > 1);
+		currentGroup.setText(configGroup.getName());
+		scrollBody.removeAll();
+
+		int row = 0;
+		for (val entry : configGroup.children()) {
+			if (entry instanceof Property) {
+				GridBagConstraints labelConstraints = new GridBagConstraints();
+				labelConstraints.gridx = 0;
+				labelConstraints.gridy = row;
+				labelConstraints.insets = SwingHelpers.PADDING;
+				labelConstraints.anchor = GridBagConstraints.EAST;
+
+				JLabel label = new JLabel(entry.getName(), JLabel.RIGHT);
+				SwingHelpers.setTooltip(label, entry.getDescription());
+				scrollBody.add(label, labelConstraints);
+
+				Property property = (Property) entry;
+				val component = TypedComponentProvider.instance().fromProperty(property);
+				if (component.isPresent()) {
+					GridBagConstraints componentConstraints = new GridBagConstraints();
+					componentConstraints.gridx = 1;
+					componentConstraints.gridy = row;
+					componentConstraints.insets = SwingHelpers.PADDING;
+					componentConstraints.weightx = 1;
+					componentConstraints.anchor = GridBagConstraints.WEST;
+					componentConstraints.fill = GridBagConstraints.HORIZONTAL;
+					scrollBody.add(component.get(), componentConstraints);
+				}
+			} else if (entry instanceof Group) {
+				Group group = (Group) entry;
+
+				GridBagConstraints groupConstraints = new GridBagConstraints();
+				groupConstraints.gridx = 0;
+				groupConstraints.gridy = row;
+				groupConstraints.gridwidth = 2;
+				groupConstraints.insets = SwingHelpers.PADDING;
+				groupConstraints.weightx = 1;
+				groupConstraints.anchor = GridBagConstraints.WEST;
+				groupConstraints.fill = GridBagConstraints.HORIZONTAL;
+
+				JButton button = new JButton(entry.getName());
+				SwingHelpers.setTooltip(button, entry.getDescription());
+				button.addActionListener(x -> pushGroup(group));
+				scrollBody.add(button, groupConstraints);
+			}
+
+			row++;
+		}
+
+		{
+			JPanel spacer = new JPanel();
+			SwingHelpers.hideBackground(spacer);
+			GridBagConstraints constraints = new GridBagConstraints();
+			constraints.gridx = 0;
+			constraints.gridy = row;
+			constraints.weighty = 1;
+			constraints.fill = GridBagConstraints.VERTICAL;
+			scrollBody.add(spacer, constraints);
+		}
+
+		scrollBody.revalidate();
+		scrollBody.repaint();
+	}
+
+}

--- a/src/main/java/net/clgd/ccemux/rendering/awt/config/ListPropertyComponent.java
+++ b/src/main/java/net/clgd/ccemux/rendering/awt/config/ListPropertyComponent.java
@@ -1,0 +1,103 @@
+package net.clgd.ccemux.rendering.awt.config;
+
+import java.awt.GridBagConstraints;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import javax.accessibility.Accessible;
+import javax.swing.JButton;
+import javax.swing.JComponent;
+
+import lombok.val;
+import net.clgd.ccemux.rendering.awt.config.TypedComponentProvider.Factory;
+
+public class ListPropertyComponent<T> extends CollectionPropertyComponent<List<T>, ListPropertyComponent.Entry> implements Accessible {
+	private static final long serialVersionUID = 7353851041165416599L;
+
+	private final Factory factory;
+	private final Type type;
+	private final Object defaultValue;
+
+	public ListPropertyComponent(
+			List<T> value, Consumer<List<T>> valueChanged,
+			TypedComponentProvider factory, Type type
+	) {
+		super(valueChanged);
+		this.type = type;
+		this.factory = factory.getFactory(type).orElse(null);
+		this.defaultValue = factory.getDefault(type).orElse(null);
+
+		for (val mapEntry : value) {
+			addEntry(new Entry(mapEntry));
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	protected void addEntry(Entry entry) {
+		super.addEntry(entry);
+
+		if (factory != null) {
+			components.add(entry.valueComponent = factory.create(entry.value, x -> {
+				entry.value = x;
+				valueChanged();
+			}, type), entry.valueConstraint);
+		}
+
+		JButton button = new JButton("X");
+		button.setToolTipText("Remove this entry");
+		button.addActionListener(e -> {
+			removeEntry(entry);
+			components.revalidate();
+			components.repaint();
+		});
+		components.add(entry.removeComponent = button, entry.removeConstraint);
+	}
+
+	@Override
+	protected void removeEntry(Entry entry) {
+		super.removeEntry(entry);
+
+		if (entry.valueComponent != null) components.remove(entry.valueComponent);
+		if (entry.removeComponent != null) components.remove(entry.removeComponent);
+	}
+
+	@Override
+	protected Entry createBlank() {
+		return new Entry(defaultValue);
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	protected List<T> toValue(List<Entry> entries) {
+		List<T> result = new ArrayList<>(entries.size());
+		for (val entry : entries) result.add((T) entry.value);
+		return result;
+	}
+
+	public static class Entry implements CollectionPropertyEntry {
+		Object value;
+		final GridBagConstraints valueConstraint, removeConstraint;
+		JComponent valueComponent, removeComponent;
+
+		Entry(Object value) {
+			this.value = value;
+
+			valueConstraint = new GridBagConstraints();
+			valueConstraint.gridx = 0;
+			valueConstraint.weightx = 1;
+			valueConstraint.insets = SwingHelpers.SMALL_PADDING;
+			valueConstraint.fill = GridBagConstraints.HORIZONTAL;
+
+			removeConstraint = new GridBagConstraints();
+			removeConstraint.gridx = 1;
+			removeConstraint.insets = SwingHelpers.SMALL_PADDING;
+		}
+
+		@Override
+		public void setRow(int index) {
+			valueConstraint.gridy = removeConstraint.gridy = index;
+		}
+	}
+}

--- a/src/main/java/net/clgd/ccemux/rendering/awt/config/MapPropertyComponent.java
+++ b/src/main/java/net/clgd/ccemux/rendering/awt/config/MapPropertyComponent.java
@@ -1,0 +1,122 @@
+package net.clgd.ccemux.rendering.awt.config;
+
+import java.awt.GridBagConstraints;
+import java.lang.reflect.Type;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import javax.accessibility.Accessible;
+import javax.swing.JButton;
+import javax.swing.JComponent;
+
+import lombok.val;
+import net.clgd.ccemux.rendering.awt.config.TypedComponentProvider.Factory;
+
+public class MapPropertyComponent<K, V> extends CollectionPropertyComponent<Map<K, V>, MapPropertyComponent.Entry> implements Accessible {
+	private static final long serialVersionUID = -5168107222176592501L;
+
+	private final Factory keyFactory, valueFactory;
+	private final Type keyType, valueType;
+	private final Object keyDefault, valueDefault;
+
+	public MapPropertyComponent(
+			Map<K, V> value, Consumer<Map<K, V>> valueChanged,
+			TypedComponentProvider factory, Type keyType, Type valueType
+	) {
+		super(valueChanged);
+		this.keyType = keyType;
+		this.valueType = valueType;
+		this.keyFactory = factory.getFactory(keyType).orElse(null);
+		this.valueFactory = factory.getFactory(valueType).orElse(null);
+		this.keyDefault = factory.getDefault(keyType).orElse(null);
+		this.valueDefault = factory.getDefault(valueType).orElse(null);
+
+		for (val mapEntry : value.entrySet()) {
+			addEntry(new Entry(mapEntry.getKey(), mapEntry.getValue()));
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	protected void addEntry(Entry entry) {
+		super.addEntry(entry);
+
+		if (keyFactory != null) {
+			components.add(entry.keyComponent = keyFactory.create(entry.key, x -> {
+				entry.key = x;
+				valueChanged();
+			}, keyType), entry.keyConstraint);
+		}
+
+		if (valueFactory != null) {
+			components.add(entry.valueComponent = valueFactory.create(entry.value, x -> {
+				entry.value = x;
+				valueChanged();
+			}, valueType), entry.valueConstraint);
+		}
+
+		JButton button = new JButton("X");
+		button.setToolTipText("Remove this entry");
+		button.addActionListener(e -> {
+			removeEntry(entry);
+			components.revalidate();
+			components.repaint();
+		});
+		components.add(entry.removeComponent = button, entry.removeConstraint);
+	}
+
+	@Override
+	protected void removeEntry(Entry entry) {
+		super.removeEntry(entry);
+
+		if (entry.keyComponent != null) components.remove(entry.keyComponent);
+		if (entry.valueComponent != null) components.remove(entry.valueComponent);
+		if (entry.removeComponent != null) components.remove(entry.removeComponent);
+	}
+
+	@Override
+	protected Entry createBlank() {
+		return new Entry(keyDefault, valueDefault);
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	protected Map<K, V> toValue(List<Entry> entries) {
+		Map<K, V> result = new LinkedHashMap<>(entries.size());
+		for (val entry : entries) result.put((K) entry.key, (V) entry.value);
+		return result;
+	}
+
+	public static class Entry implements CollectionPropertyEntry {
+		Object key, value;
+		final GridBagConstraints keyConstraint, valueConstraint, removeConstraint;
+		JComponent keyComponent, valueComponent, removeComponent;
+
+		Entry(Object key, Object value) {
+			this.key = key;
+			this.value = value;
+
+			keyConstraint = new GridBagConstraints();
+			keyConstraint.gridx = 0;
+			keyConstraint.weightx = 1;
+			keyConstraint.insets = SwingHelpers.SMALL_PADDING;
+			keyConstraint.fill = GridBagConstraints.HORIZONTAL;
+
+			valueConstraint = new GridBagConstraints();
+			valueConstraint.gridx = 1;
+			valueConstraint.weightx = 1;
+			valueConstraint.insets = SwingHelpers.SMALL_PADDING;
+			valueConstraint.fill = GridBagConstraints.HORIZONTAL;
+
+			removeConstraint = new GridBagConstraints();
+			removeConstraint.gridx = 2;
+			removeConstraint.insets = SwingHelpers.SMALL_PADDING;
+		}
+
+		@Override
+		public void setRow(int index) {
+			keyConstraint.gridy = valueConstraint.gridy = removeConstraint.gridy = index;
+		}
+	}
+}

--- a/src/main/java/net/clgd/ccemux/rendering/awt/config/SwingHelpers.java
+++ b/src/main/java/net/clgd/ccemux/rendering/awt/config/SwingHelpers.java
@@ -1,0 +1,27 @@
+package net.clgd.ccemux.rendering.awt.config;
+
+import java.awt.Insets;
+import java.util.Optional;
+
+import javax.swing.JComponent;
+
+import com.google.common.html.HtmlEscapers;
+
+public class SwingHelpers {
+	public static final Insets PADDING = new Insets(5, 5, 5, 5);
+	public static final Insets SMALL_PADDING = new Insets(2, 2, 2, 2);
+
+	public static void hideBackground(JComponent component) {
+		component.setOpaque(false);
+		component.setBackground(null);
+		component.setBorder(null);
+	}
+
+	public static void setTooltip(JComponent component, Optional<String> tooltip) {
+		if (tooltip.isPresent()) {
+			component.setToolTipText("<html>" + HtmlEscapers.htmlEscaper().escape(tooltip.get()).replace("\n", "<br />") + "</html>");
+		} else {
+			component.setToolTipText(null);
+		}
+	}
+}

--- a/src/main/java/net/clgd/ccemux/rendering/awt/config/TypedComponentProvider.java
+++ b/src/main/java/net/clgd/ccemux/rendering/awt/config/TypedComponentProvider.java
@@ -1,0 +1,164 @@
+package net.clgd.ccemux.rendering.awt.config;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.*;
+import java.util.function.Consumer;
+
+import javax.swing.*;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+
+import com.google.common.primitives.Booleans;
+import com.google.common.primitives.Doubles;
+import com.google.common.primitives.Ints;
+import com.google.common.primitives.Longs;
+import com.google.common.reflect.TypeToken;
+import com.google.gson.JsonPrimitive;
+import lombok.val;
+import net.clgd.ccemux.config.Property;
+
+public class TypedComponentProvider {
+	private static final TypedComponentProvider instance = new TypedComponentProvider();
+
+	public interface Factory<T> {
+		JComponent create(T value, Consumer<T> valueChanged, Type baseType);
+	}
+
+	private final Map<Class<?>, Factory<?>> types = new HashMap<>();
+	private final Map<Class<?>, Object> defaultValues = new HashMap<>();
+
+	public <T> void register(Class<T> type, T defaultValue, Factory<T> property) {
+		types.put(type, property);
+		defaultValues.put(type, defaultValue);
+	}
+
+	private static Type extractBase(Type type) {
+		if (type instanceof Class<?>) {
+			return type;
+		} else if (type instanceof ParameterizedType) {
+			return ((ParameterizedType) type).getRawType();
+		} else {
+			return type;
+		}
+	}
+
+	@SuppressWarnings("SuspiciousMethodCalls")
+	public Optional<Factory<?>> getFactory(Type type) {
+		return Optional.ofNullable(types.get(extractBase(type)));
+	}
+
+	@SuppressWarnings("SuspiciousMethodCalls")
+	public Optional<Object> getDefault(Type type) {
+		return Optional.ofNullable(defaultValues.get(extractBase(type)));
+	}
+
+	@SuppressWarnings("unchecked")
+	public Optional<JComponent> fromProperty(Property property) {
+		return getFactory(property.getType())
+				.map((Factory x) -> x.create(property.get(), property::set, property.getType()));
+	}
+
+	public static TypedComponentProvider instance() {
+		return instance;
+	}
+
+	@SuppressWarnings("unchecked")
+	public TypedComponentProvider() {
+		register(Integer.class, 0, (value, callback, ty) -> {
+			val model = new SpinnerNumberModel((int) value, Integer.MIN_VALUE, Integer.MAX_VALUE, 1);
+			val spinner = new JSpinner(model);
+			spinner.addChangeListener(e -> callback.accept(model.getNumber().intValue()));
+			return spinner;
+		});
+
+		register(Long.class, 0L, (value, callback, ty) -> {
+			val model = new SpinnerNumberModel((long) value, Long.MIN_VALUE, Long.MAX_VALUE, 1);
+			val spinner = new JSpinner(model);
+			spinner.addChangeListener(e -> callback.accept(model.getNumber().longValue()));
+			return spinner;
+		});
+
+		register(Double.class, 0d, (value, callback, ty) -> {
+			val model = new SpinnerNumberModel(value, null, null, 1);
+			val spinner = new JSpinner(model);
+			spinner.addChangeListener(e -> callback.accept(model.getNumber().doubleValue()));
+			return spinner;
+		});
+
+		register(Boolean.class, false, (value, callback, ty) -> {
+			val checkbox = new JCheckBox();
+			checkbox.getModel().setSelected(value);
+			checkbox.setBackground(null);
+			checkbox.addItemListener(e -> callback.accept(checkbox.getModel().isSelected()));
+			return checkbox;
+		});
+
+		register(String.class, "", (value, callback, ty) -> {
+			val text = new JTextField();
+			text.setText(value);
+			text.getDocument().addDocumentListener(new ChangeListener(() -> callback.accept(text.getText())));
+			return text;
+		});
+
+		register(JsonPrimitive.class, new JsonPrimitive(""), (value, callback, ty) -> {
+			val text = new JTextField();
+			text.setText(value == null ? "" : value.getAsString());
+			text.getDocument().addDocumentListener(new ChangeListener(() ->
+					callback.accept(new JsonPrimitive(text.getText()))));
+			return text;
+		});
+
+		register(Map.class, Collections.emptyMap(), (value, callback, ty) -> {
+			TypeToken base = TypeToken.of(ty);
+			ParameterizedType ofMap = (ParameterizedType) base.getSupertype(Map.class).getType();
+			Type[] arguments = ofMap.getActualTypeArguments();
+			return new MapPropertyComponent(value, callback, this, arguments[0], arguments[1]);
+		});
+
+		register(List.class, Collections.emptyList(), (value, callback, ty) -> {
+			TypeToken base = TypeToken.of(ty);
+			ParameterizedType ofList = (ParameterizedType) base.getSupertype(List.class).getType();
+			Type[] arguments = ofList.getActualTypeArguments();
+			return new ListPropertyComponent(value, callback, this, arguments[0]);
+		});
+
+		register(int[].class, new int[0], (value, callback, ty) ->
+				new ListPropertyComponent<>(Ints.asList(value), c -> callback.accept(Ints.toArray(c)), this, Integer.class));
+
+		register(long[].class, new long[0], (value, callback, ty) ->
+				new ListPropertyComponent<>(Longs.asList(value), c -> callback.accept(Longs.toArray(c)), this, Long.class));
+
+		register(double[].class, new double[0], (value, callback, ty) ->
+				new ListPropertyComponent<>(Doubles.asList(value), c -> callback.accept(Doubles.toArray(c)), this, Double.class));
+
+		register(boolean[].class, new boolean[0], (value, callback, ty) ->
+				new ListPropertyComponent<>(Booleans.asList(value), c -> callback.accept(Booleans.toArray(c)), this, Booleans.class));
+
+		register(String[].class, new String[0], (value, callback, ty) ->
+				new ListPropertyComponent<>(Arrays.asList(value), c -> callback.accept(c.toArray(new String[c.size()])), this, String.class));
+	}
+
+	private static class ChangeListener implements DocumentListener {
+		private final Runnable action;
+
+		private ChangeListener(Runnable action) {
+			this.action = action;
+		}
+
+		@Override
+		public void insertUpdate(DocumentEvent e) {
+			action.run();
+		}
+
+		@Override
+		public void removeUpdate(DocumentEvent e) {
+			action.run();
+		}
+
+		@Override
+		public void changedUpdate(DocumentEvent e) {
+			action.run();
+		}
+	}
+}

--- a/src/main/resources/rom/emu_program.lua
+++ b/src/main/resources/rom/emu_program.lua
@@ -6,6 +6,7 @@ if ccemux then
         print("emu close - close this computer")
         print("emu open [id] - open another computer")
         print("emu data - opens the data folder")
+        print("emu config - opens the config editor")
         --print("emu set <setting> <values> - edits a setting")
         --print("emu list settings - list editable settings")
         --print("emu save - saves current settings")
@@ -24,6 +25,13 @@ if ccemux then
                 print("Opened data folder")
             else
                 print("Unable to open data folder")
+            end
+        elseif args[1] == "config" then
+            local ok, err = ccemux.openConfig()
+            if ok then
+                print("Opened config editor")
+            else
+                print(err)
             end
         elseif args[1] == "set" then
             if #args <= 1 then


### PR DESCRIPTION
 - Configs are statically defined using `Property<T>` and `Group`.
 - Each plugin gets a config section under `plugins` -> `<class name>`.
 - `JsonAdapter` converts a given config object to and from a `JsonElement`. Ideally this would preserve commented out fields, invalid fields, etc... when saving but I'm not sure how.
 - `ConfigView` takes an arbitrary config object and displays it in a swing window. Ideally this would be abstracted into the renderer somehow.