### PR TITLE
Update to the latest CCTweaks-Lua version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ dependencies {
 	implementation 'commons-cli:commons-cli:1.4'
 	implementation 'org.apache.commons:commons-lang3:3.6'
 
-	implementation 'org.squiddev:cctweaks-lua:1.5.0-pr2'
+	implementation 'org.squiddev:cctweaks-lua:1.5.0-pr3'
 
 	implementation 'com.google.guava:guava:22.0'
 	implementation 'com.google.code.gson:gson:2.8.1'

--- a/src/main/java/net/clgd/ccemux/init/CCEmuXClassloader.java
+++ b/src/main/java/net/clgd/ccemux/init/CCEmuXClassloader.java
@@ -1,26 +1,24 @@
 package net.clgd.ccemux.init;
 
-import java.net.URL;
-
-import org.squiddev.cctweaks.lua.launch.RewritingLoader;
+import org.squiddev.cctweaks.lua.launch.DelegatingRewritingLoader;
 
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class CCEmuXClassloader extends RewritingLoader {
+public class CCEmuXClassloader extends DelegatingRewritingLoader {
 	public static final String CC_PREFIX = "dan200.computercraft";
-	
+
 	private boolean blockCC = true;
-	
-	CCEmuXClassloader(URL[] urls) {
-		super(urls);
+
+	CCEmuXClassloader(ClassLoader delegate) {
+		super(delegate);
 		addClassLoaderExclusion(CCEmuXClassloader.class.getName());
 	}
-	
+
 	public void allowCC() {
 		this.blockCC = false;
 	}
-	
+
 	@Override
 	public Class<?> findClass(String name) throws ClassNotFoundException {
 		if (name.startsWith(CC_PREFIX) && blockCC) {

--- a/src/main/java/net/clgd/ccemux/plugins/builtin/CCTweaksPlugin.java
+++ b/src/main/java/net/clgd/ccemux/plugins/builtin/CCTweaksPlugin.java
@@ -3,20 +3,19 @@ package net.clgd.ccemux.plugins.builtin;
 import java.awt.GraphicsEnvironment;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Map;
 import java.util.Optional;
 
 import javax.swing.JOptionPane;
 
+import org.squiddev.cctweaks.lua.ConfigMetadata;
 import org.squiddev.cctweaks.lua.TweaksLogger;
+import org.squiddev.cctweaks.lua.launch.ClassLoaderHelpers;
 import org.squiddev.cctweaks.lua.launch.RewritingLoader;
 import org.squiddev.cctweaks.lua.lib.ApiRegister;
 
 import com.google.auto.service.AutoService;
-import com.google.gson.JsonPrimitive;
-import com.google.gson.reflect.TypeToken;
 import lombok.extern.slf4j.Slf4j;
-import lombok.val;
+import net.clgd.ccemux.config.ConfigEntry;
 import net.clgd.ccemux.config.Group;
 import net.clgd.ccemux.config.Property;
 import net.clgd.ccemux.emulation.EmuConfig;
@@ -25,7 +24,7 @@ import net.clgd.ccemux.plugins.Plugin;
 @Slf4j
 @AutoService(Plugin.class)
 public class CCTweaksPlugin extends Plugin {
-	private Property<Map<String, JsonPrimitive>> options;
+	private Group options;
 
 	@Override
 	public String getName() {
@@ -54,23 +53,30 @@ public class CCTweaksPlugin extends Plugin {
 
 	@Override
 	public void configSetup(Group group) {
-		options = group.property("options", new TypeToken<Map<String, JsonPrimitive>>() {}, Collections.emptyMap())
-				.setName("Options")
-				.setDescription("Key-value configuration options to be passed to CCTweaks");
+		options = group;
+		for (ConfigMetadata.Category category : ConfigMetadata.categories()) {
+			configSetup(group, category);
+		}
 	}
 
-	private void syncConfig() {
-		for (val option : options.get().entrySet()) {
-			System.setProperty("cctweaks." + option.getKey(), option.getValue().getAsString());
+	private void configSetup(Group parent, ConfigMetadata.Category category) {
+		Group group = parent.group(category.name());
+		if (category.description() != null) parent.setDescription(category.description());
+
+		for (ConfigMetadata.Category child : category.children()) {
+			configSetup(group, child);
+		}
+
+		for (ConfigMetadata.Property property : category.properties()) {
+			Property<?> groupProp = group.property(property.name(), property.type(), property.defaultValue());
+			if (property.description() != null) groupProp.setName(property.name());
+			groupProp.addAndFireListener((a, b) -> property.set(b));
 		}
 	}
 
 	@Override
 	public void loaderSetup(EmuConfig cfg, ClassLoader loader) {
-		syncConfig();
-
 		if (loader instanceof RewritingLoader) {
-
 			TweaksLogger.instance = org.squiddev.patcher.Logger.instance = new org.squiddev.patcher.Logger() {
 				@Override
 				public void doDebug(String message) {
@@ -89,31 +95,25 @@ public class CCTweaksPlugin extends Plugin {
 			};
 
 			RewritingLoader rwLoader = (RewritingLoader) loader;
+			Optional<ConfigEntry> entry = options.group("testing").child("dumpAsm");
+			if (entry.isPresent() && entry.get() instanceof Property) {
+				((Property<Boolean>) entry.get()).addAndFireListener((a, b) -> rwLoader.dump(b));
+			}
 
 			try {
-				// Thread.currentThread().setContextClassLoader(loader);
-
-				rwLoader.loadConfig();
-				rwLoader.loadChain();
+				ClassLoaderHelpers.setupChain((ClassLoader & RewritingLoader) loader);
 			} catch (Exception e) {
 				log.warn("Failed to apply classloader tweaks", e);
 			}
-
-			options.addListener((x, y) -> {
-				syncConfig();
-				try {
-					rwLoader.loadConfig();
-				} catch (Exception e) {
-					log.warn("Failed to refresh config", e);
-				}
-			});
 		} else {
 			log.warn("Incompatible ClassLoader in use - CCTweaks functionality unavailable");
 
-			if (!GraphicsEnvironment.isHeadless()) JOptionPane.showMessageDialog(null,
-					"Your configuration is incompatible with the CCTweaks plugin.\n"
-							+ "Please consult the logs for more information.",
-					"CCTweaks unavailable", JOptionPane.WARNING_MESSAGE);
+			if (!GraphicsEnvironment.isHeadless()) {
+				JOptionPane.showMessageDialog(null,
+						"Your configuration is incompatible with the CCTweaks plugin.\n"
+								+ "Please consult the logs for more information.",
+						"CCTweaks unavailable", JOptionPane.WARNING_MESSAGE);
+			}
 		}
 	}
 
@@ -122,5 +122,4 @@ public class CCTweaksPlugin extends Plugin {
 		ApiRegister.init();
 		ApiRegister.loadPlugins();
 	}
-
 }


### PR DESCRIPTION
 - Generate config properties/groups from metadata produced by ConfigGen.
 - Update `CCEmuXClassLoader` to use the new DelegatingClassLoader, meaning we can run on Java 9.

I haven't actually pushed a new CCTweaks-Lua version yet - I want to check this is OK before finalising anything.

---

This is what the config GUI looks like for CCTweaks-Lua. The names aren't localised which is a bit of a pain, but I'm not too sure what to do about that.

![image](https://user-images.githubusercontent.com/4346137/32699869-5cd98aca-c7b4-11e7-80f4-23b4276ccc28.png)
