### PR TITLE
Optionally listen to native VK_PASTE key

### DIFF
--- a/src/main/java/net/clgd/ccemux/emulation/EmulatedComputer.java
+++ b/src/main/java/net/clgd/ccemux/emulation/EmulatedComputer.java
@@ -14,17 +14,17 @@ import org.apache.commons.io.IOUtils;
 import dan200.computercraft.api.filesystem.IWritableMount;
 import dan200.computercraft.core.computer.Computer;
 import dan200.computercraft.core.computer.IComputerEnvironment;
-import lombok.val;
 import lombok.extern.slf4j.Slf4j;
+import lombok.val;
 
 /**
  * Represents a computer that can be emulated via CCEmuX
- * 
+ *
  * @author apemanzilla
  *
  */
 @Slf4j
-public class EmulatedComputer extends Computer {	
+public class EmulatedComputer extends Computer {
 	private static final Field rootMountField;
 
 	static {
@@ -40,10 +40,10 @@ public class EmulatedComputer extends Computer {
 
 		rootMountField = f;
 	}
-	
+
 	/**
 	 * A class used to create new <code>EmulatedComputer</code> instances
-	 * 
+	 *
 	 * @author apemanzilla
 	 *
 	 */
@@ -68,7 +68,7 @@ public class EmulatedComputer extends Computer {
 		 * Sets the ID of the computer to construct. Setting the id to
 		 * <code>null</code> (the default value) will result in the ID being
 		 * automatically chosen by the environment.
-		 * 
+		 *
 		 * @return This builder, for chaining
 		 */
 		public Builder id(Integer num) {
@@ -80,7 +80,7 @@ public class EmulatedComputer extends Computer {
 		 * Sets the root (<code>/</code>) mount of the computer to construct.
 		 * Setting the root mount to <code>null</code> (the default value) will
 		 * result in one being created by the environment.
-		 * 
+		 *
 		 * @param rootMount
 		 *            The writable mount to use as a root mount
 		 * @return This builder, for chaining
@@ -94,7 +94,7 @@ public class EmulatedComputer extends Computer {
 		 * Sets the label of the computer to construct. Setting the label to
 		 * <code>null</code> (the default value) will result in no label being
 		 * set.
-		 * 
+		 *
 		 * @return This builder, for chaining
 		 */
 		public Builder label(String label) {
@@ -128,7 +128,7 @@ public class EmulatedComputer extends Computer {
 
 	/**
 	 * Gets a new builder to create an <code>EmulatedComputer</code> instance
-	 * 
+	 *
 	 * @return
 	 */
 	public static Builder builder(IComputerEnvironment env, EmulatedTerminal term) {
@@ -166,8 +166,12 @@ public class EmulatedComputer extends Computer {
 		listeners.forEach(l -> l.onAdvance(dt));
 	}
 
-	public void pressKey(int keycode, boolean release) {
-		queueEvent(release ? "key_up" : "key", new Object[] { keycode });
+	public void pressKey(int keycode, boolean repeat) {
+		queueEvent("key", new Object[] { keycode, repeat });
+	}
+
+	public void releaseKey(int keycode) {
+		queueEvent("key_up", new Object[] { keycode });
 	}
 
 	public void pressChar(char c) {
@@ -193,13 +197,13 @@ public class EmulatedComputer extends Computer {
 	public void scroll(int lines, int x, int y) {
 		queueEvent("mouse_scroll", new Object[] { lines, x, y });
 	}
-	
+
 	/**
 	 * Copies the given files into this computer's root mount at the given
 	 * location. All files will be copied into the destination regardless of
 	 * their absolute path, with their original name. Directories will be
 	 * recursively copied into the destination in a similar fashion to files.
-	 * 
+	 *
 	 * @param files
 	 *            The files to copy
 	 */
@@ -207,13 +211,13 @@ public class EmulatedComputer extends Computer {
 		if (rootMountField == null) throw new IllegalStateException("No reference to root mount, cannot write files to computer");
 		val mount = (IWritableMount) rootMountField.get(this);
 		val base = Paths.get(location);
-		
+
 		for (val f : files) {
 			val path = base.resolve(f.getName()).toString();
-			
+
 			if (f.isFile()) {
 				if (f.length() > mount.getRemainingSpace()) throw new IOException("Not enough space on computer");
-				
+
 				val s = mount.openForWrite(path);
 				IOUtils.copy(FileUtils.openInputStream(f), s);
 			} else {

--- a/src/main/java/net/clgd/ccemux/plugins/builtin/AWTPlugin.java
+++ b/src/main/java/net/clgd/ccemux/plugins/builtin/AWTPlugin.java
@@ -8,6 +8,8 @@ import java.util.Optional;
 import javax.swing.JFrame;
 
 import com.google.auto.service.AutoService;
+import net.clgd.ccemux.config.ConfigProperty;
+import net.clgd.ccemux.config.Group;
 import net.clgd.ccemux.emulation.EmuConfig;
 import net.clgd.ccemux.emulation.EmulatedComputer;
 import net.clgd.ccemux.plugins.Plugin;
@@ -18,6 +20,8 @@ import net.clgd.ccemux.rendering.awt.config.ConfigView;
 
 @AutoService(Plugin.class)
 public class AWTPlugin extends Plugin {
+	private AWTConfig config;
+
 	@Override
 	public String getName() {
 		return "AWT Renderer";
@@ -44,13 +48,18 @@ public class AWTPlugin extends Plugin {
 	}
 
 	@Override
+	public void configSetup(Group group) {
+		config = new AWTConfig(group);
+	}
+
+	@Override
 	public void setup(EmuConfig cfg) {
 		RendererFactory.implementations.put("AWT", new RendererFactory<Renderer>() {
 			private WeakReference<JFrame> lastFrame = null;
 
 			@Override
 			public Renderer create(EmulatedComputer computer, EmuConfig cfg) {
-				return new AWTRenderer(computer, cfg);
+				return new AWTRenderer(computer, cfg, config);
 			}
 
 			@Override
@@ -70,5 +79,15 @@ public class AWTPlugin extends Plugin {
 				return true;
 			}
 		});
+	}
+
+	public static class AWTConfig {
+		public final ConfigProperty<Boolean> nativePaste;
+
+		AWTConfig(Group group) {
+			nativePaste = group.property("nativePaste", boolean.class, false)
+					.setName("Use native paste")
+					.setDescription("Listen to native paste events instead of Ctrl+V. This may not work on all platforms.");
+		}
 	}
 }

--- a/src/main/java/net/clgd/ccemux/plugins/builtin/AWTPlugin.java
+++ b/src/main/java/net/clgd/ccemux/plugins/builtin/AWTPlugin.java
@@ -87,7 +87,7 @@ public class AWTPlugin extends Plugin {
 		AWTConfig(Group group) {
 			nativePaste = group.property("nativePaste", boolean.class, false)
 					.setName("Use native paste")
-					.setDescription("Listen to native paste events instead of Ctrl+V. This may not work on all platforms.");
+					.setDescription("Listen to native paste events instead of Ctrl+V.");
 		}
 	}
 }

--- a/src/main/java/net/clgd/ccemux/rendering/awt/AWTRenderer.java
+++ b/src/main/java/net/clgd/ccemux/rendering/awt/AWTRenderer.java
@@ -17,7 +17,11 @@ import java.util.BitSet;
 import java.util.List;
 
 import javax.imageio.ImageIO;
+import javax.swing.InputMap;
 import javax.swing.JOptionPane;
+import javax.swing.KeyStroke;
+import javax.swing.UIManager;
+import javax.swing.text.DefaultEditorKit;
 
 import org.apache.commons.io.IOUtils;
 
@@ -296,7 +300,9 @@ public class AWTRenderer implements Renderer, KeyListener, MouseListener, MouseM
 		// Pasting should be handled first as it blocks all events
 		boolean hasModifier = (e.getModifiers() & Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()) != 0;
 		if (rendererConfig.nativePaste.get()
-			? e.getKeyCode() == KeyEvent.VK_PASTE
+			? DefaultEditorKit.pasteAction.equals(
+				((InputMap) UIManager.getLookAndFeelDefaults().get("TextField.focusInputMap"))
+						.get(KeyStroke.getKeyStrokeForEvent(e)))
 			: hasModifier && e.getKeyCode() == KeyEvent.VK_V) {
 			try {
 				computer.paste((String) Toolkit.getDefaultToolkit().getSystemClipboard().getData(DataFlavor.stringFlavor));


### PR DESCRIPTION
Also ensure the repeat parameter of key down events are fired. Closes #38.

This doesn't appear to work on Windows, so I'd appreciate testing on other platforms. If it doesn't work there then I'll cherry pick the other fixes directly.

I'm sorry about the whitespace changes, but I didn't really want to go and fix each one manually. Can everyone make sure whitespace is trimmed in their editor configuration?