### PR TITLE
Move renderer registration into an interface

### DIFF
--- a/plugin-api/src/main/java/net/clgd/ccemux/api/plugins/Plugin.java
+++ b/plugin-api/src/main/java/net/clgd/ccemux/api/plugins/Plugin.java
@@ -122,7 +122,7 @@ public abstract class Plugin {
 	 * before CC is loaded and should not be used unless you know what you're
 	 * doing!
 	 *
-	 * @see #setup(EmuConfig)
+	 * @see #setup(PluginManager)
 	 * @see #configSetup(Group)
 	 */
 	public void loaderSetup(EmuConfig cfg, ClassLoader loader) {}
@@ -138,7 +138,7 @@ public abstract class Plugin {
 	 *
 	 * @see Hook
 	 */
-	public abstract void setup(EmuConfig cfg);
+	public abstract void setup(PluginManager manager);
 
 	public final String toString() {
 		return getName() + getVersion().map(v -> " v" + v).orElse("");

--- a/plugin-api/src/main/java/net/clgd/ccemux/api/plugins/PluginManager.java
+++ b/plugin-api/src/main/java/net/clgd/ccemux/api/plugins/PluginManager.java
@@ -1,0 +1,28 @@
+package net.clgd.ccemux.api.plugins;
+
+import net.clgd.ccemux.api.emulation.EmuConfig;
+import net.clgd.ccemux.api.rendering.RendererFactory;
+
+/**
+ * Used when initialising plugins in order to register various providers.
+ *
+ * @see Plugin#setup(PluginManager)
+ */
+public interface PluginManager {
+	/**
+	 * The configuration for the emulator.
+	 *
+	 * @return This emulator's config options.
+	 */
+	EmuConfig config();
+
+	/**
+	 * Register a new renderer factory
+	 *
+	 * @param name    The name of this renderer factory
+	 * @param factory The factory to register
+	 * @throws NullPointerException  If either argument is {@code null}
+	 * @throws IllegalStateException If there is already a renderer with the same name.
+	 */
+	void addRenderer(String name, RendererFactory<?> factory);
+}

--- a/plugin-api/src/main/java/net/clgd/ccemux/api/rendering/RendererFactory.java
+++ b/plugin-api/src/main/java/net/clgd/ccemux/api/rendering/RendererFactory.java
@@ -15,11 +15,6 @@ import net.clgd.ccemux.api.emulation.EmulatedComputer;
 @FunctionalInterface
 public interface RendererFactory<T extends Renderer> {
 	/**
-	 * A map of names to renderer factories
-	 */
-	public static final Map<String, RendererFactory<?>> implementations = new HashMap<>();
-
-	/**
 	 * Creates a renderer for the given computer and config
 	 */
 	public T create(EmulatedComputer computer, EmuConfig cfg);
@@ -30,7 +25,7 @@ public interface RendererFactory<T extends Renderer> {
 	 * returned.<br>
 	 * <br>
 	 * The default implementation returns false and has no side effects.
-	 * 
+	 *
 	 * @param config
 	 *            The config to let the user edit
 	 * @return Whether an editor window was opened

--- a/src/main/java/net/clgd/ccemux/init/Launcher.java
+++ b/src/main/java/net/clgd/ccemux/init/Launcher.java
@@ -242,7 +242,7 @@ public class Launcher {
 			String renderer;
 			if (cli.hasOption('r') && cli.getOptionValue('r') == null) {
 				log.info("Available rendering methods:");
-				RendererFactory.implementations.keySet().stream().forEach(k -> log.info(" {}", k));
+				pluginMgr.getRenderers().keySet().forEach(k -> log.info(" {}", k));
 				System.exit(0);
 				return;
 			} else if (cli.hasOption('r')) {
@@ -251,7 +251,7 @@ public class Launcher {
 				renderer = cfg.renderer.get();
 			}
 
-			RendererFactory renderFactory = RendererFactory.implementations.get(renderer);
+			RendererFactory renderFactory = pluginMgr.getRenderers().get(renderer);
 			if (renderFactory == null) {
 				log.error("Specified renderer '{}' does not exist - are you missing a plugin?", renderer);
 

--- a/src/main/java/net/clgd/ccemux/plugins/builtin/AWTPlugin.java
+++ b/src/main/java/net/clgd/ccemux/plugins/builtin/AWTPlugin.java
@@ -14,6 +14,7 @@ import net.clgd.ccemux.api.config.Group;
 import net.clgd.ccemux.api.emulation.EmuConfig;
 import net.clgd.ccemux.api.emulation.EmulatedComputer;
 import net.clgd.ccemux.api.plugins.Plugin;
+import net.clgd.ccemux.api.plugins.PluginManager;
 import net.clgd.ccemux.api.rendering.Renderer;
 import net.clgd.ccemux.api.rendering.RendererFactory;
 import net.clgd.ccemux.rendering.awt.AWTRenderer;
@@ -54,8 +55,8 @@ public class AWTPlugin extends Plugin {
 	}
 
 	@Override
-	public void setup(EmuConfig cfg) {
-		RendererFactory.implementations.put("AWT", new RendererFactory<Renderer>() {
+	public void setup(PluginManager manager) {
+		manager.addRenderer("AWT", new RendererFactory<Renderer>() {
 			private WeakReference<JFrame> lastFrame = null;
 
 			@Override

--- a/src/main/java/net/clgd/ccemux/plugins/builtin/CCEmuXAPI.java
+++ b/src/main/java/net/clgd/ccemux/plugins/builtin/CCEmuXAPI.java
@@ -22,11 +22,11 @@ import dan200.computercraft.api.lua.LuaException;
 import dan200.computercraft.core.apis.ArgumentHelper;
 import dan200.computercraft.core.apis.ILuaAPI;
 import lombok.extern.slf4j.Slf4j;
-import net.clgd.ccemux.api.emulation.EmuConfig;
 import net.clgd.ccemux.api.emulation.EmulatedComputer;
 import net.clgd.ccemux.api.emulation.Emulator;
 import net.clgd.ccemux.api.emulation.filesystem.VirtualDirectory.Builder;
 import net.clgd.ccemux.api.plugins.Plugin;
+import net.clgd.ccemux.api.plugins.PluginManager;
 import net.clgd.ccemux.api.plugins.hooks.ComputerCreated;
 import net.clgd.ccemux.api.plugins.hooks.CreatingROM;
 import net.clgd.ccemux.api.emulation.filesystem.VirtualFile;
@@ -151,7 +151,7 @@ public class CCEmuXAPI extends Plugin {
 	}
 
 	@Override
-	public void setup(EmuConfig cfg) {
+	public void setup(PluginManager manager) {
 		registerHook(new ComputerCreated() {
 			@Override
 			public void onComputerCreated(Emulator emu, EmulatedComputer computer) {

--- a/src/main/java/net/clgd/ccemux/plugins/builtin/CCTweaksPlugin.java
+++ b/src/main/java/net/clgd/ccemux/plugins/builtin/CCTweaksPlugin.java
@@ -21,6 +21,7 @@ import net.clgd.ccemux.api.config.ConfigProperty;
 import net.clgd.ccemux.api.config.Group;
 import net.clgd.ccemux.api.emulation.EmuConfig;
 import net.clgd.ccemux.api.plugins.Plugin;
+import net.clgd.ccemux.api.plugins.PluginManager;
 
 @Slf4j
 @AutoService(Plugin.class)
@@ -119,7 +120,7 @@ public class CCTweaksPlugin extends Plugin {
 	}
 
 	@Override
-	public void setup(EmuConfig cfg) {
+	public void setup(PluginManager cfg) {
 		ApiRegister.init();
 		ApiRegister.loadPlugins();
 	}

--- a/src/main/java/net/clgd/ccemux/plugins/builtin/HDFontPlugin.java
+++ b/src/main/java/net/clgd/ccemux/plugins/builtin/HDFontPlugin.java
@@ -1,11 +1,13 @@
 package net.clgd.ccemux.plugins.builtin;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
 
 import com.google.auto.service.AutoService;
 
-import net.clgd.ccemux.api.emulation.EmuConfig;
 import net.clgd.ccemux.api.plugins.Plugin;
+import net.clgd.ccemux.api.plugins.PluginManager;
 import net.clgd.ccemux.api.rendering.TerminalFont;
 
 @AutoService(Plugin.class)
@@ -37,7 +39,7 @@ public class HDFontPlugin extends Plugin {
 	}
 
 	@Override
-	public void setup(EmuConfig cfg) {
+	public void setup(PluginManager manager) {
 		TerminalFont.registerFont(HDFontPlugin.class.getResource("/img/hdfont.png"));
 	}
 }

--- a/src/main/java/net/clgd/ccemux/plugins/builtin/JFXPlugin.java
+++ b/src/main/java/net/clgd/ccemux/plugins/builtin/JFXPlugin.java
@@ -9,9 +9,8 @@ import com.google.auto.service.AutoService;
 import net.clgd.ccemux.api.OperatingSystem;
 import net.clgd.ccemux.api.config.ConfigProperty;
 import net.clgd.ccemux.api.config.Group;
-import net.clgd.ccemux.api.emulation.EmuConfig;
 import net.clgd.ccemux.api.plugins.Plugin;
-import net.clgd.ccemux.api.rendering.RendererFactory;
+import net.clgd.ccemux.api.plugins.PluginManager;
 import net.clgd.ccemux.rendering.javafx.JFXRendererFactory;
 
 @AutoService(Plugin.class)
@@ -57,7 +56,7 @@ public class JFXPlugin extends Plugin {
 	}
 
 	@Override
-	public void setup(EmuConfig cfg) {
-		RendererFactory.implementations.put("JFX", new JFXRendererFactory());
+	public void setup(PluginManager manager) {
+		manager.addRenderer("JFX", new JFXRendererFactory());
 	}
 }

--- a/src/main/java/net/clgd/ccemux/plugins/builtin/TRoRPlugin.java
+++ b/src/main/java/net/clgd/ccemux/plugins/builtin/TRoRPlugin.java
@@ -6,9 +6,8 @@ import java.util.Optional;
 
 import com.google.auto.service.AutoService;
 
-import net.clgd.ccemux.api.emulation.EmuConfig;
 import net.clgd.ccemux.api.plugins.Plugin;
-import net.clgd.ccemux.api.rendering.RendererFactory;
+import net.clgd.ccemux.api.plugins.PluginManager;
 import net.clgd.ccemux.rendering.tror.TRoRRenderer;
 
 @AutoService(Plugin.class)
@@ -39,7 +38,7 @@ public class TRoRPlugin extends Plugin {
 	}
 
 	@Override
-	public void setup(EmuConfig cfg) {
-		RendererFactory.implementations.put("TRoR", TRoRRenderer::new);
+	public void setup(PluginManager manager) {
+		manager.addRenderer("TRoR", TRoRRenderer::new);
 	}
 }


### PR DESCRIPTION
This is slightly more elegant (and foolproof) than just exposing a raw hashmap.