### PR TITLE
Peripherals

### DIFF
--- a/plugin-api/src/main/java/net/clgd/ccemux/api/emulation/Emulator.java
+++ b/plugin-api/src/main/java/net/clgd/ccemux/api/emulation/Emulator.java
@@ -3,6 +3,7 @@ package net.clgd.ccemux.api.emulation;
 import java.io.File;
 import java.util.function.Consumer;
 
+import net.clgd.ccemux.api.peripheral.PeripheralFactory;
 import net.clgd.ccemux.api.rendering.Renderer;
 import net.clgd.ccemux.api.rendering.RendererFactory;
 
@@ -21,6 +22,14 @@ public interface Emulator {
 	public <T extends Renderer> RendererFactory<T> getRendererFactory();
 
 	/**
+	 * Get the peripheral factory with the given name
+	 *
+	 * @param name The peripheral factory to find
+	 * @return The peripheral factory or {@code null} if it cannot be found
+	 */
+	PeripheralFactory<?> getPeripheralFactory(String name);
+
+	/**
 	 * Gets the config used by this config
 	 */
 	public EmuConfig getConfig();
@@ -32,7 +41,7 @@ public interface Emulator {
 
 	/**
 	 * Creates and adds a new computer, returning the created instance
-	 * 
+	 *
 	 * @param builderMutator
 	 *            A mutator that is passed the computer builder to make any
 	 *            necessary changes before the computer is built
@@ -42,7 +51,7 @@ public interface Emulator {
 
 	/**
 	 * Creates and adds a new computer, returning the created instance
-	 * 
+	 *
 	 * @return The computer instance
 	 */
 	public default EmulatedComputer createComputer() {
@@ -51,7 +60,7 @@ public interface Emulator {
 
 	/**
 	 * Removes the given computer
-	 * 
+	 *
 	 * @param computer
 	 *            The computer to remove
 	 * @return Whether the computer was removed

--- a/plugin-api/src/main/java/net/clgd/ccemux/api/peripheral/Peripheral.java
+++ b/plugin-api/src/main/java/net/clgd/ccemux/api/peripheral/Peripheral.java
@@ -1,0 +1,27 @@
+package net.clgd.ccemux.api.peripheral;
+
+import dan200.computercraft.api.peripheral.IPeripheral;
+import net.clgd.ccemux.api.config.Group;
+import net.clgd.ccemux.api.emulation.EmulatedComputer;
+
+public interface Peripheral extends IPeripheral, EmulatedComputer.Listener {
+	/**
+	 * Setup any configuration options this peripheral requires.
+	 *
+	 * For instance, modems may wish to provide configuration options for their
+	 * position and range.
+	 *
+	 * @param group The group to load config elements from.
+	 */
+	default void configSetup(Group group) { }
+
+	/**
+	 * Called when the owning computer is ticked in order to perform any processing
+	 * which must be done on the main thread.
+	 *
+	 * @param dt The change in time in seconds since the last update. This will normally be
+	 *           around {@code 0.05}.
+	 */
+	@Override
+	default void onAdvance(double dt) { }
+}

--- a/plugin-api/src/main/java/net/clgd/ccemux/api/peripheral/PeripheralFactory.java
+++ b/plugin-api/src/main/java/net/clgd/ccemux/api/peripheral/PeripheralFactory.java
@@ -1,0 +1,20 @@
+package net.clgd.ccemux.api.peripheral;
+
+import net.clgd.ccemux.api.emulation.EmuConfig;
+import net.clgd.ccemux.api.emulation.EmulatedComputer;
+
+/**
+ * A factory used to create a peripheral for a given computer
+ *
+ * @param <T> The type of peripheral created by this factory
+ */
+@FunctionalInterface
+public interface PeripheralFactory<T extends Peripheral> {
+	/**
+	 * Creates a peripheral for the given computer and config.
+	 *
+	 * A peripheral may implement {@link EmulatedComputer.Listener} in order to be updated
+	 * every tick.
+	 */
+	T create(EmulatedComputer computer, EmuConfig cfg);
+}

--- a/plugin-api/src/main/java/net/clgd/ccemux/api/plugins/PluginManager.java
+++ b/plugin-api/src/main/java/net/clgd/ccemux/api/plugins/PluginManager.java
@@ -1,6 +1,7 @@
 package net.clgd.ccemux.api.plugins;
 
 import net.clgd.ccemux.api.emulation.EmuConfig;
+import net.clgd.ccemux.api.peripheral.PeripheralFactory;
 import net.clgd.ccemux.api.rendering.RendererFactory;
 
 /**
@@ -25,4 +26,14 @@ public interface PluginManager {
 	 * @throws IllegalStateException If there is already a renderer with the same name.
 	 */
 	void addRenderer(String name, RendererFactory<?> factory);
+
+	/**
+	 * Register a new peripheral factory
+	 *
+	 * @param name    The name of the factory
+	 * @param factory The factory to register
+	 * @throws NullPointerException  If either argument is {@code null}
+	 * @throws IllegalStateException If there is already a peripheral with the same name.
+	 */
+	void addPeripheral(String name, PeripheralFactory<?> factory);
 }

--- a/src/main/java/net/clgd/ccemux/config/LuaAdapter.java
+++ b/src/main/java/net/clgd/ccemux/config/LuaAdapter.java
@@ -1,0 +1,183 @@
+package net.clgd.ccemux.config;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.Type;
+import java.util.*;
+
+import javax.annotation.Nonnull;
+
+import com.google.common.primitives.Primitives;
+import com.google.gson.reflect.TypeToken;
+import dan200.computercraft.api.lua.LuaException;
+import dan200.computercraft.core.apis.ArgumentHelper;
+import net.clgd.ccemux.api.config.ConfigEntry;
+import net.clgd.ccemux.api.config.ConfigProperty;
+import net.clgd.ccemux.api.config.Group;
+
+/**
+ * An adapter for ComputerCraft's Lua objects, which attempts to convert between
+ * config groups/properties and CC's HashMap + primitives.
+ */
+public final class LuaAdapter {
+	private LuaAdapter() {}
+
+	public static Map<String, Object> toLua(Group group, Object existing) {
+		Map<String, Object> object = existing instanceof Map ? (Map) existing : new HashMap<>();
+
+		for (ConfigEntry entry : group.children()) {
+			if (entry instanceof ConfigProperty<?>) {
+				ConfigProperty<?> property = (ConfigProperty<?>) entry;
+
+				// Don't emit default options
+				if (!property.isDefault() || property.isAlwaysEmit()) {
+					object.put(entry.getKey(), toLua(property.get()));
+				}
+			} else if (entry instanceof Group) {
+				Map<String, Object> element = toLua((Group) entry, object.get(entry.getKey()));
+
+				// Don't emit empty groups
+				if (element.size() > 0) object.put(entry.getKey(), element);
+			}
+		}
+
+		return object;
+	}
+
+	public static Map<String, Object> toDefaultJson(Group group) {
+		Map<String, Object> object = new HashMap<>();
+		for (ConfigEntry entry : group.children()) {
+			if (entry instanceof ConfigProperty<?>) {
+				ConfigProperty<?> property = (ConfigProperty<?>) entry;
+				object.put(entry.getKey(), toLua(property.getDefaultValue()));
+			} else if (entry instanceof Group) {
+				object.put(entry.getKey(), toDefaultJson((Group) entry));
+			}
+		}
+
+		return object;
+	}
+
+	public static void fromLua(Group group, Object element) throws LuaException {
+		if (!(element instanceof Map)) {
+			throw new LuaException(String.format("bad key '%s' for property group (table expected, got %s)",
+				group.getKey(),
+				ArgumentHelper.getType(element)));
+		}
+
+		for (Map.Entry<?, ?> entry : ((Map<?, ?>) element).entrySet()) {
+			if (!(entry.getKey() instanceof String)) {
+				throw new LuaException(String.format("unexpected key of type '%s' in group '%s'",
+					ArgumentHelper.getType(entry.getKey()), group.getKey()));
+			}
+
+			String key = (String) entry.getKey();
+			if (key.startsWith("_")) continue;
+
+			Optional<ConfigEntry> configEntry = group.child(key);
+			if (configEntry.isPresent()) {
+				if (configEntry.get() instanceof Group) {
+					fromLua((Group) configEntry.get(), entry.getValue());
+				} else if (configEntry.get() instanceof ConfigProperty<?>) {
+					ConfigProperty property = (ConfigProperty<?>) configEntry.get();
+
+					try {
+						// noinspection unchecked
+						property.set(fromValue(entry.getValue(), property.getType()));
+					} catch (IllegalArgumentException e) {
+						throw new LuaException(String.format(
+							"Cannot parse property '%s' in group '%s' (%s)",
+							entry.getKey(), group.getKey(), e.getMessage())
+						);
+					}
+				}
+			} else {
+				throw new LuaException(String.format("Unknown property '%s' in group '%s'", key, group.getKey()));
+			}
+		}
+	}
+
+	private static Object toLua(Object input) {
+		if (input instanceof Collection<?>) {
+			int i = 0;
+			HashMap<Integer, Object> result = new HashMap<>();
+			for (Object value : (Collection<?>) input) result.put(i++, toLua(value));
+			return result;
+		} else if (input.getClass().isArray()) {
+			int i = 0;
+			HashMap<Integer, Object> result = new HashMap<>();
+			for (Object value : (Object[]) input) result.put(i++, toLua(value));
+			return result;
+		} else {
+			return input;
+		}
+	}
+
+	private static Object fromValue(Object input, Type type) throws IllegalArgumentException {
+		TypeToken<?> typeToken = TypeToken.get(type);
+		Class<?> klass = typeToken.getRawType();
+		if (Primitives.isWrapperType(klass)) klass = Primitives.unwrap(klass);
+
+		if (klass == int.class) {
+			if (input instanceof Number) return ((Number) input).intValue();
+		} else if (klass == long.class) {
+			if (input instanceof Number) return ((Number) input).longValue();
+		} else if (klass == double.class) {
+			if (input instanceof Number) return ((Number) input).doubleValue();
+		} else if (klass == boolean.class) {
+			if (input instanceof Boolean) return input;
+		} else if (klass == String.class) {
+			if (input instanceof String) return input;
+		} else if (klass.isArray()) {
+			if (input instanceof Map) {
+				Map<Object, Object> map = new HashMap<>((Map<?, ?>) input);
+
+				int maxKey = 0;
+				while (map.containsKey(maxKey + 1)) maxKey++;
+
+				Object array = Array.newInstance(klass.getComponentType(), maxKey);
+				for (int i = 0; i <= maxKey; i++) {
+					Array.set(array, i, fromValue(map.remove(i + 1), klass.getComponentType()));
+				}
+
+				Iterator<Object> keys = map.keySet().iterator();
+				if (keys.hasNext()) {
+					throw new IllegalArgumentException(String.format("Unexpected key of type '%s'",
+						ArgumentHelper.getType(keys.next())));
+				}
+				return array;
+			}
+		}
+
+		throw new IllegalArgumentException(String.format(
+			"%s expected, got %s",
+			getType(klass), ArgumentHelper.getType(input)));
+	}
+
+
+	@Nonnull
+	private static String getType(Class<?> type) {
+		if (type == null) {
+			return "nil";
+		} else if (type == String.class) {
+			return "string";
+		} else if (type == boolean.class) {
+			return "boolean";
+		} else if (type == double.class || type == long.class || type == int.class) {
+			return "number";
+		} else if (Map.class.isAssignableFrom(type)) {
+			return "table";
+		} else {
+			if (!type.isArray()) {
+				return type.getName();
+			} else {
+				StringBuilder name;
+				for (name = new StringBuilder(); type.isArray(); type = type.getComponentType()) {
+					name.append("[]");
+				}
+
+				name.insert(0, type.getName());
+				return name.toString();
+			}
+		}
+	}
+}

--- a/src/main/java/net/clgd/ccemux/emulation/CCEmuX.java
+++ b/src/main/java/net/clgd/ccemux/emulation/CCEmuX.java
@@ -26,6 +26,7 @@ import net.clgd.ccemux.api.emulation.EmulatedTerminal;
 import net.clgd.ccemux.api.emulation.Emulator;
 import net.clgd.ccemux.api.emulation.filesystem.VirtualDirectory;
 import net.clgd.ccemux.api.emulation.filesystem.VirtualMount;
+import net.clgd.ccemux.api.peripheral.PeripheralFactory;
 import net.clgd.ccemux.api.rendering.Renderer;
 import net.clgd.ccemux.api.rendering.RendererFactory;
 import net.clgd.ccemux.plugins.PluginManager;
@@ -75,6 +76,11 @@ public class CCEmuX implements Runnable, Emulator, IComputerEnvironment {
 		return getVersion();
 	}
 
+	@Override
+	public PeripheralFactory<?> getPeripheralFactory(String name) {
+		return pluginMgr.getPeripherals().get(name);
+	}
+
 	/**
 	 * Creates a new computer and renderer, applying config settings and plugin
 	 * hooks appropriately.
@@ -90,7 +96,7 @@ public class CCEmuX implements Runnable, Emulator, IComputerEnvironment {
 	/**
 	 * Creates a new computer and renderer, applying config settings and plugin
 	 * hooks appropriately. Additionally takes a {@link Consumer} which will be
-	 * called on the {@link EmulatedComputer.BuilderImpl} after plugin hooks, which
+	 * called on the {@link EmulatedComputer.Builder} after plugin hooks, which
 	 * can be used to change the computers ID or other properties.
 	 *
 	 * @param builderMutator

--- a/src/main/java/net/clgd/ccemux/emulation/EmulatedComputerImpl.java
+++ b/src/main/java/net/clgd/ccemux/emulation/EmulatedComputerImpl.java
@@ -12,9 +12,10 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 
 import dan200.computercraft.api.filesystem.IWritableMount;
+import dan200.computercraft.api.peripheral.IPeripheral;
 import dan200.computercraft.core.computer.IComputerEnvironment;
-import lombok.val;
 import lombok.extern.slf4j.Slf4j;
+import lombok.val;
 import net.clgd.ccemux.api.emulation.EmulatedComputer;
 import net.clgd.ccemux.api.emulation.EmulatedTerminal;
 
@@ -65,7 +66,7 @@ public class EmulatedComputerImpl extends EmulatedComputer {
 
 		/*
 		 * (non-Javadoc)
-		 * 
+		 *
 		 * @see net.clgd.ccemux.emulation.Builder#id(java.lang.Integer)
 		 */
 		@Override
@@ -76,7 +77,7 @@ public class EmulatedComputerImpl extends EmulatedComputer {
 
 		/*
 		 * (non-Javadoc)
-		 * 
+		 *
 		 * @see net.clgd.ccemux.emulation.Builder#rootMount(dan200.computercraft.api.
 		 * filesystem.IWritableMount)
 		 */
@@ -88,7 +89,7 @@ public class EmulatedComputerImpl extends EmulatedComputer {
 
 		/*
 		 * (non-Javadoc)
-		 * 
+		 *
 		 * @see net.clgd.ccemux.emulation.Builder#label(java.lang.String)
 		 */
 		@Override
@@ -99,7 +100,7 @@ public class EmulatedComputerImpl extends EmulatedComputer {
 
 		/*
 		 * (non-Javadoc)
-		 * 
+		 *
 		 * @see net.clgd.ccemux.emulation.Builder#build()
 		 */
 		@Override
@@ -162,6 +163,11 @@ public class EmulatedComputerImpl extends EmulatedComputer {
 	@Override
 	public void advance(double dt) {
 		super.advance(dt);
+
+		for(int i = 0; i < 6; i++) {
+			IPeripheral peripheral = getPeripheral(i);
+			if (peripheral instanceof Listener) ((Listener) peripheral).onAdvance(dt);
+		}
 
 		listeners.forEach(l -> l.onAdvance(dt));
 	}

--- a/src/main/java/net/clgd/ccemux/plugins/PluginManager.java
+++ b/src/main/java/net/clgd/ccemux/plugins/PluginManager.java
@@ -14,6 +14,7 @@ import net.clgd.ccemux.api.emulation.EmulatedComputer;
 import net.clgd.ccemux.api.emulation.EmulatedComputer.Builder;
 import net.clgd.ccemux.api.emulation.Emulator;
 import net.clgd.ccemux.api.emulation.filesystem.VirtualDirectory;
+import net.clgd.ccemux.api.peripheral.PeripheralFactory;
 import net.clgd.ccemux.api.plugins.Plugin;
 import net.clgd.ccemux.api.plugins.hooks.*;
 import net.clgd.ccemux.api.rendering.Renderer;
@@ -37,6 +38,7 @@ public class PluginManager implements Closing, CreatingComputer, CreatingROM, Co
 	private final List<PluginCandidate> candidates = new ArrayList<>();
 	private final List<Plugin> enabled = new ArrayList<>();
 	private final Map<String, RendererFactory<?>> renderers = new HashMap<>();
+	private final Map<String, PeripheralFactory<?>> peripherals = new HashMap<>();
 
 	public PluginManager(EmuConfig cfg) {
 		this.cfg = cfg;
@@ -165,7 +167,23 @@ public class PluginManager implements Closing, CreatingComputer, CreatingROM, Co
 		renderers.put(name, factory);
 	}
 
+	@Override
+	public void addPeripheral(String name, PeripheralFactory<?> factory) {
+		Preconditions.checkNotNull(name, "name cannot be null");
+		Preconditions.checkNotNull(factory, "factory cannot be null");
+
+		if (peripherals.containsKey(name)) {
+			throw new IllegalStateException("Renderer with name '" + name + "'  already registered.");
+		}
+
+		peripherals.put(name, factory);
+	}
+
 	public Map<String, RendererFactory<?>> getRenderers() {
 		return Collections.unmodifiableMap(renderers);
+	}
+
+	public Map<String, PeripheralFactory<?>> getPeripherals() {
+		return Collections.unmodifiableMap(peripherals);
 	}
 }

--- a/src/main/java/net/clgd/ccemux/plugins/builtin/peripherals/DefaultPeripheralsPlugin.java
+++ b/src/main/java/net/clgd/ccemux/plugins/builtin/peripherals/DefaultPeripheralsPlugin.java
@@ -1,0 +1,53 @@
+package net.clgd.ccemux.plugins.builtin.peripherals;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+
+import com.google.auto.service.AutoService;
+import net.clgd.ccemux.api.emulation.EmuConfig;
+import net.clgd.ccemux.api.emulation.EmulatedComputer;
+import net.clgd.ccemux.api.peripheral.Peripheral;
+import net.clgd.ccemux.api.peripheral.PeripheralFactory;
+import net.clgd.ccemux.api.plugins.Plugin;
+import net.clgd.ccemux.api.plugins.PluginManager;
+
+@AutoService(Plugin.class)
+public class DefaultPeripheralsPlugin extends Plugin {
+	@Override
+	public String getName() {
+		return "Default Peripherals";
+	}
+
+	@Override
+	public String getDescription() {
+		return "Provides various peripherals which are built-in to ComputerCraft";
+	}
+
+	@Override
+	public Optional<String> getVersion() {
+		return Optional.empty();
+	}
+
+	@Override
+	public Collection<String> getAuthors() {
+		return Collections.singleton("CLGD");
+	}
+
+	@Override
+	public Optional<String> getWebsite() {
+		return Optional.empty();
+	}
+
+	@Override
+	@SuppressWarnings("Convert2Lambda")
+	public void setup(PluginManager manager) {
+		// We need to use anonymous classes in order to defer the loading of IPeripheral
+		manager.addPeripheral("wireless_modem", new PeripheralFactory<Peripheral>() {
+			@Override
+			public Peripheral create(EmulatedComputer c, EmuConfig e) {
+				return new WirelessModemPeripheral();
+			}
+		});
+	}
+}

--- a/src/main/java/net/clgd/ccemux/plugins/builtin/peripherals/Packet.java
+++ b/src/main/java/net/clgd/ccemux/plugins/builtin/peripherals/Packet.java
@@ -1,0 +1,72 @@
+package net.clgd.ccemux.plugins.builtin.peripherals;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import com.google.common.base.Preconditions;
+
+public class Packet {
+	private final int channel;
+	private final int replyChannel;
+	private final Object payload;
+	private final WirelessModemPeripheral sender;
+
+	public Packet(int channel, int replyChannel, @Nullable Object payload, @Nonnull WirelessModemPeripheral sender) {
+		Preconditions.checkNotNull(sender, "sender cannot be null");
+		this.channel = channel;
+		this.replyChannel = replyChannel;
+		this.payload = payload;
+		this.sender = sender;
+	}
+
+	public int getChannel() {
+		return this.channel;
+	}
+
+	public int getReplyChannel() {
+		return this.replyChannel;
+	}
+
+	@Nullable
+	public Object getPayload() {
+		return this.payload;
+	}
+
+	@Nonnull
+	public WirelessModemPeripheral getSender() {
+		return this.sender;
+	}
+
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		} else if (o != null && this.getClass() == o.getClass()) {
+			Packet packet = (Packet) o;
+			if (this.channel != packet.channel) {
+				return false;
+			} else if (this.replyChannel != packet.replyChannel) {
+				return false;
+			} else {
+				if (this.payload != null) {
+					if (!this.payload.equals(packet.payload)) {
+						return false;
+					}
+				} else if (packet.payload != null) {
+					return false;
+				}
+
+				return this.sender.equals(packet.sender);
+			}
+		} else {
+			return false;
+		}
+	}
+
+	public int hashCode() {
+		int result = this.channel;
+		result = 31 * result + this.replyChannel;
+		result = 31 * result + (this.payload != null ? this.payload.hashCode() : 0);
+		result = 31 * result + this.sender.hashCode();
+		return result;
+	}
+}

--- a/src/main/java/net/clgd/ccemux/plugins/builtin/peripherals/WirelessModemPeripheral.java
+++ b/src/main/java/net/clgd/ccemux/plugins/builtin/peripherals/WirelessModemPeripheral.java
@@ -1,0 +1,187 @@
+package net.clgd.ccemux.plugins.builtin.peripherals;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import dan200.computercraft.api.lua.ILuaContext;
+import dan200.computercraft.api.lua.LuaException;
+import dan200.computercraft.api.peripheral.IComputerAccess;
+import dan200.computercraft.api.peripheral.IPeripheral;
+import dan200.computercraft.core.apis.ArgumentHelper;
+import net.clgd.ccemux.api.config.ConfigProperty;
+import net.clgd.ccemux.api.config.Group;
+import net.clgd.ccemux.api.peripheral.Peripheral;
+
+public class WirelessModemPeripheral implements Peripheral {
+	private static final Set<WirelessModemPeripheral> modems = new HashSet<>();
+
+	private IComputerAccess computer = null;
+	private final Set<Integer> channels = new HashSet<>();
+	private boolean open = false;
+
+	private ConfigProperty<Integer> range;
+	private ConfigProperty<Boolean> interdimensional;
+	private ConfigProperty<String> world;
+	private ConfigProperty<Integer> posX;
+	private ConfigProperty<Integer> posY;
+	private ConfigProperty<Integer> posZ;
+
+	@Override
+	public void configSetup(Group group) {
+		range = group.property("range", Integer.class, 64);
+		interdimensional = group.property("interdimensional", Boolean.class, false);
+
+		world = group.property("world", String.class, "main");
+		posX = group.property("posX", Integer.class, 0);
+		posY = group.property("posY", Integer.class, 0);
+		posZ = group.property("posZ", Integer.class, 0);
+	}
+
+	private void receiveSameDimension(@Nonnull Packet packet, double distance) {
+		if (packet.getSender() != this) {
+			synchronized (this) {
+				if (computer != null && channels.contains(packet.getChannel())) {
+					computer.queueEvent("modem_message", new Object[] { computer.getAttachmentName(), packet.getChannel(), packet.getReplyChannel(), packet.getPayload(), distance });
+				}
+			}
+		}
+	}
+
+	private void receiveDifferentDimension(@Nonnull Packet packet) {
+		if (packet.getSender() != this) {
+			synchronized (this) {
+				if (computer != null && channels.contains(packet.getChannel())) {
+					computer.queueEvent("modem_message", new Object[] { computer.getAttachmentName(), packet.getChannel(), packet.getReplyChannel(), packet.getPayload() });
+				}
+			}
+		}
+	}
+
+	@Nonnull
+	public String getType() {
+		return "modem";
+	}
+
+	@Nonnull
+	public String[] getMethodNames() {
+		return new String[] {
+			"open",
+			"isOpen",
+			"close",
+			"closeAll",
+			"transmit",
+			"isWireless",
+		};
+	}
+
+	private static int parseChannel(Object[] arguments, int index) throws LuaException {
+		int channel = ArgumentHelper.getInt(arguments, index);
+		if (channel >= 0 && channel <= 65535) {
+			return channel;
+		} else {
+			throw new LuaException("Expected number in range 0-65535");
+		}
+	}
+
+	public Object[] callMethod(@Nonnull IComputerAccess computer, @Nonnull ILuaContext context, int method, @Nonnull Object[] arguments) throws LuaException, InterruptedException {
+		switch (method) {
+			case 0: { // open
+				int channel = parseChannel(arguments, 0);
+				synchronized (this) {
+					if (!channels.contains(channel)) {
+						if (channels.size() >= 128) {
+							throw new LuaException("Too many open channels");
+						}
+
+						channels.add(channel);
+						open = true;
+					}
+				}
+
+				return null;
+			}
+			case 1: { // isOpen
+				int channel = parseChannel(arguments, 0);
+				synchronized (this) {
+					boolean open = channels.contains(channel);
+					return new Object[] { open };
+				}
+			}
+			case 2: { // close
+				int channel = parseChannel(arguments, 0);
+				synchronized (this) {
+					if (channels.remove(channel) && channels.size() == 0) open = false;
+
+					return null;
+				}
+			}
+			case 3: // closeAll
+				synchronized (this) {
+					if (channels.size() > 0) {
+						channels.clear();
+						open = false;
+					}
+
+					return null;
+				}
+			case 4: { // transmit
+				int channel = parseChannel(arguments, 0);
+				int replyChannel = parseChannel(arguments, 1);
+				Object payload = arguments.length >= 3 ? arguments[2] : null;
+				synchronized (this) {
+					Packet packet = new Packet(channel, replyChannel, payload, this);
+					synchronized (modems) {
+						for (WirelessModemPeripheral receiver : modems) receiver.tryTransmit(packet);
+					}
+					return null;
+				}
+			}
+			case 5: // isWireless
+				return new Object[] { true };
+			default:
+				return null;
+		}
+	}
+
+	private void tryTransmit(Packet packet) {
+		WirelessModemPeripheral sender = packet.getSender();
+		if (world.get().equals(sender.world.get())) {
+			double receiveRange = Math.max(sender.range.get(), range.get());
+			double distanceSq
+				= Math.pow(posX.get() - sender.posX.get(), 2)
+				+ Math.pow(posY.get() - sender.posY.get(), 2)
+				+ Math.pow(posZ.get() - sender.posZ.get(), 2);
+
+			if (interdimensional.get() || sender.interdimensional.get() || distanceSq <= receiveRange * receiveRange) {
+				receiveSameDimension(packet, Math.sqrt(distanceSq));
+			}
+		} else if (interdimensional.get() || sender.interdimensional.get()) {
+			receiveDifferentDimension(packet);
+		}
+	}
+
+	public synchronized void attach(@Nonnull IComputerAccess computer) {
+		this.computer = computer;
+		open = !channels.isEmpty();
+		synchronized (modems) {
+			modems.add(this);
+		}
+	}
+
+	public synchronized void detach(@Nonnull IComputerAccess computer) {
+		synchronized (modems) {
+			modems.remove(this);
+		}
+		channels.clear();
+		this.computer = null;
+		if (open) open = false;
+	}
+
+	@Override
+	public boolean equals(@Nullable IPeripheral other) {
+		return this == other;
+	}
+}


### PR DESCRIPTION
![](https://media.discordapp.net/attachments/412382509649756162/432540877190332416/unknown.png)

I'm not entirely sure about the implementation, but it'll do. Some things to consider:

 - [ ] Do we want to provide a way of updating a peripheral's properties without creating a new one?
 - [ ] Should we just pass the config group to the peripheral factory instead of having a separate method?

Some things for the future:
 - [ ] Peripheral storage! As we're using the config system this should be fairly easy to do once #33 is implemented.
 - [ ] On a similar note, config GUI support: it would be nice to modify a peripheral's settings with the GUI.
 - [ ] More peripherals (#26). Disk drives should be relatively easy, but monitors will require renderer support, which is going to be tricky... There's a bit of me which wants to query the `.minecraft` directory for resources so we do speakers, but that might be a little overkill :P.