### PR TITLE
Fix typo in TRoRRenderer.java affecting TB package.

### DIFF
--- a/src/main/java/net/clgd/ccemux/rendering/tror/TRoRRenderer.java
+++ b/src/main/java/net/clgd/ccemux/rendering/tror/TRoRRenderer.java
@@ -249,7 +249,7 @@ public class TRoRRenderer implements Renderer, EmulatedTerminal.Listener, Emulat
 
 	@Override
 	public void setCursorBlink(boolean blink) {
-		sendLine("TB", blink ? "true" : "faalse");
+		sendLine("TB", blink ? "true" : "false");
 	}
 
 	@Override


### PR DESCRIPTION
Changed "faalse" to "false" in the setCursorBlink function.