### PR TITLE
Fix up a bunch of warnings

### DIFF
--- a/plugin-api/src/main/java/net/clgd/ccemux/api/OperatingSystem.java
+++ b/plugin-api/src/main/java/net/clgd/ccemux/api/OperatingSystem.java
@@ -19,7 +19,7 @@ public enum OperatingSystem {
 	/**
 	 * Gets the directory that should be used for storing application data for this
 	 * OS
-	 * 
+	 *
 	 * @return The directory that application data should be stored in
 	 */
 	@Nonnull
@@ -35,19 +35,20 @@ public enum OperatingSystem {
 
 	/**
 	 * Gets the OS this program is running on
-	 * 
+	 *
 	 * @return The appropriate value for this OS
 	 */
 	@Nonnull
 	public static OperatingSystem get() {
 		String name = System.getProperty("os.name");
-		if (name.startsWith("Windows"))
+		if (name.startsWith("Windows")) {
 			return Windows;
-		else if (name.startsWith("Linux"))
+		} else if (name.startsWith("Linux")) {
 			return Linux;
-		else if (name.startsWith("Mac"))
+		} else if (name.startsWith("Mac")) {
 			return MacOSX;
-		else
+		} else {
 			return Other;
+		}
 	}
 }

--- a/plugin-api/src/main/java/net/clgd/ccemux/api/Utils.java
+++ b/plugin-api/src/main/java/net/clgd/ccemux/api/Utils.java
@@ -10,7 +10,7 @@ import javax.annotation.Nonnull;
 public final class Utils {
 	/**
 	 * Gets the global cursor blink
-	 * 
+	 *
 	 * @return Whether a blinking cursor should be shown right now
 	 */
 	public static boolean getGlobalCursorBlink() {
@@ -21,9 +21,8 @@ public final class Utils {
 
 	/**
 	 * Converts a single hexadecimal character to an int
-	 * 
-	 * @param c
-	 *            The hexadecimal character
+	 *
+	 * @param c The hexadecimal character
 	 * @return The associated int, or -1 if the character is invalid
 	 */
 	public static int base16ToInt(char c) {
@@ -32,12 +31,10 @@ public final class Utils {
 
 	/**
 	 * Converts an int to matching hexadecimal character
-	 * 
-	 * @param p
-	 *            An integer on the range [0, 15]
+	 *
+	 * @param p An integer on the range [0, 15]
 	 * @return The matching hexadecimal character
-	 * @throws IndexOutOfBoundsException
-	 *             if the integer is not on the range [0, 15]
+	 * @throws IndexOutOfBoundsException if the integer is not on the range [0, 15]
 	 */
 	public static char intToBase16(int p) {
 		return BASE_16.charAt(p);
@@ -45,13 +42,10 @@ public final class Utils {
 
 	/**
 	 * Constrains the given decimal value to a given range
-	 * 
-	 * @param val
-	 *            The value
-	 * @param min
-	 *            The bottom bound of the range
-	 * @param max
-	 *            The upper bound of the range
+	 *
+	 * @param val The value
+	 * @param min The bottom bound of the range
+	 * @param max The upper bound of the range
 	 * @return The value, constrained to the range [min, max]
 	 */
 	public static double constrainToRange(double val, double min, double max) {
@@ -60,21 +54,19 @@ public final class Utils {
 
 	/**
 	 * Clamps a set of three doubles (RGB values) to the range [0, 1]
-	 * 
-	 * @param col
-	 *            The three values
+	 *
+	 * @param col The three values
 	 * @return A new array with the constrained values
 	 */
 	@Nonnull
 	public static double[] clampColor(@Nonnull double[] col) {
-		return new double[] {constrainToRange(col[0], 0, 1), constrainToRange(col[1], 0, 1), constrainToRange(col[2], 0, 1)};
+		return new double[] { constrainToRange(col[0], 0, 1), constrainToRange(col[1], 0, 1), constrainToRange(col[2], 0, 1) };
 	}
 
 	/**
 	 * Checks if a character is printable
-	 * 
-	 * @param c
-	 *            The character
+	 *
+	 * @param c The character
 	 * @return Whether the character is printable
 	 */
 	public static boolean isPrintableChar(char c) {

--- a/plugin-api/src/main/java/net/clgd/ccemux/api/config/Config.java
+++ b/plugin-api/src/main/java/net/clgd/ccemux/api/config/Config.java
@@ -22,16 +22,12 @@ public class Config {
 	/**
 	 * Create a new property with the given key and add it to the config file.
 	 *
-	 * @param key
-	 *            The property's unique key.
-	 * @param type
-	 *            The type of this property's value.
-	 * @param defaultValue
-	 *            The default value of this property.
+	 * @param key          The property's unique key.
+	 * @param type         The type of this property's value.
+	 * @param defaultValue The default value of this property.
 	 * @return The newly created property.
-	 * @throws IllegalStateException
-	 *             If an entry with the same key exists.
-	 * @see ConfigProperty#Property(String, TypeToken, Object)
+	 * @throws IllegalStateException If an entry with the same key exists.
+	 * @see ConfigProperty(String, TypeToken, Object)
 	 */
 	@Nonnull
 	public <T> ConfigProperty<T> property(@Nonnull String key, @Nonnull TypeToken<T> type, @Nonnull T defaultValue) {
@@ -41,16 +37,12 @@ public class Config {
 	/**
 	 * Create a new property with the given key and add it to the config file.
 	 *
-	 * @param key
-	 *            The property's unique key.
-	 * @param type
-	 *            The type of this property's value.
-	 * @param defaultValue
-	 *            The default value of this property.
+	 * @param key          The property's unique key.
+	 * @param type         The type of this property's value.
+	 * @param defaultValue The default value of this property.
 	 * @return The newly created property.
-	 * @throws IllegalStateException
-	 *             If an entry with the same key exists.
-	 * @see ConfigProperty#Property(String, Class, Object)
+	 * @throws IllegalStateException If an entry with the same key exists.
+	 * @see ConfigProperty(String, Class, Object)
 	 */
 	@Nonnull
 	public <T> ConfigProperty<T> property(@Nonnull String key, @Nonnull Class<T> type, @Nonnull T defaultValue) {
@@ -60,11 +52,9 @@ public class Config {
 	/**
 	 * Lookup a group with the given key, or create a new one.
 	 *
-	 * @param key
-	 *            The group's key.
+	 * @param key The group's key.
 	 * @return A group with the given key.
-	 * @throws IllegalStateException
-	 *             If a _property_ with the same name exists.
+	 * @throws IllegalStateException If a _property_ with the same name exists.
 	 */
 	@Nonnull
 	public Group group(@Nonnull String key) throws IllegalStateException {

--- a/plugin-api/src/main/java/net/clgd/ccemux/api/config/ConfigProperty.java
+++ b/plugin-api/src/main/java/net/clgd/ccemux/api/config/ConfigProperty.java
@@ -2,7 +2,9 @@ package net.clgd.ccemux.api.config;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 import java.util.function.BiConsumer;
 
 import javax.annotation.Nonnull;
@@ -13,14 +15,13 @@ import com.google.common.reflect.TypeToken;
 /**
  * An entry in a config file which stores a value of the given type.
  *
- * @param <T>
- *            The type of value to store.
+ * @param <T> The type of value to store.
  */
 public class ConfigProperty<T> extends ConfigEntry {
 	private final List<BiConsumer<T, T>> listeners = new ArrayList<>(0);
 
 	private final String key;
-	
+
 	@Nonnull
 	public String getKey() {
 		return key;
@@ -32,15 +33,15 @@ public class ConfigProperty<T> extends ConfigEntry {
 	public String getName() {
 		return name;
 	}
-	
+
 	@Nonnull
 	public ConfigProperty<T> setName(@Nonnull String name) {
 		this.name = name;
 		return this;
 	}
-	
+
 	private String description;
-	
+
 	@Nonnull
 	public ConfigProperty<T> setDescription(@Nullable String description) {
 		this.description = description;
@@ -119,14 +120,10 @@ public class ConfigProperty<T> extends ConfigEntry {
 	/**
 	 * Create a new property with the given key and add it to the group.
 	 *
-	 * @param key
-	 *            The property's unique key.
-	 * @param type
-	 *            The type of this property's value.
-	 * @param defaultValue
-	 *            The default value of this property.
-	 * @throws IllegalStateException
-	 *             If an entry with the same key exists.
+	 * @param key          The property's unique key.
+	 * @param type         The type of this property's value.
+	 * @param defaultValue The default value of this property.
+	 * @throws IllegalStateException If an entry with the same key exists.
 	 * @see Group#property(String, Class, Object)
 	 */
 	public ConfigProperty(@Nonnull String key, @Nonnull Class<T> type, T defaultValue) {
@@ -136,14 +133,10 @@ public class ConfigProperty<T> extends ConfigEntry {
 	/**
 	 * Create a new property with the given key and add it to the group.
 	 *
-	 * @param key
-	 *            The property's unique key.
-	 * @param type
-	 *            The type of this property's value.
-	 * @param defaultValue
-	 *            The default value of this property.
-	 * @throws IllegalStateException
-	 *             If an entry with the same key exists.
+	 * @param key          The property's unique key.
+	 * @param type         The type of this property's value.
+	 * @param defaultValue The default value of this property.
+	 * @throws IllegalStateException If an entry with the same key exists.
 	 * @see Group#property(String, TypeToken, Object)
 	 */
 	public ConfigProperty(@Nonnull String key, @Nonnull TypeToken<T> type, T defaultValue) {
@@ -162,8 +155,7 @@ public class ConfigProperty<T> extends ConfigEntry {
 	/**
 	 * Change the value of this property, marking it as dirty and firing listeners.
 	 *
-	 * @param newValue
-	 *            The value to change the property to.
+	 * @param newValue The value to change the property to.
 	 * @see #resetDefault()
 	 */
 	public void set(T newValue) {
@@ -176,8 +168,9 @@ public class ConfigProperty<T> extends ConfigEntry {
 			T oldValue = value;
 			value = newValue;
 
-			for (BiConsumer<T, T> listener : listeners)
+			for (BiConsumer<T, T> listener : listeners) {
 				listener.accept(oldValue, newValue);
+			}
 		}
 	}
 
@@ -213,9 +206,8 @@ public class ConfigProperty<T> extends ConfigEntry {
 	/**
 	 * Add a listener which observes value changes.
 	 *
-	 * @param listener
-	 *            The event listener. This receives the old and new values as
-	 *            arguments.
+	 * @param listener The event listener. This receives the old and new values as
+	 *                 arguments.
 	 * @see #addAndFireListener(BiConsumer)
 	 * @see #removeListener(BiConsumer)
 	 */
@@ -234,9 +226,8 @@ public class ConfigProperty<T> extends ConfigEntry {
 	 * }
 	 * </pre>
 	 *
-	 * @param listener
-	 *            The event listener. This receives the old and new values as
-	 *            arguments.
+	 * @param listener The event listener. This receives the old and new values as
+	 *                 arguments.
 	 * @see #addListener(BiConsumer)
 	 * @see #removeListener(BiConsumer)
 	 */
@@ -248,8 +239,7 @@ public class ConfigProperty<T> extends ConfigEntry {
 	/**
 	 * Remove a property change listener
 	 *
-	 * @param listener
-	 *            The event listener to remove.
+	 * @param listener The event listener to remove.
 	 * @see #addListener(BiConsumer)
 	 * @see #addAndFireListener(BiConsumer)
 	 */

--- a/plugin-api/src/main/java/net/clgd/ccemux/api/config/Group.java
+++ b/plugin-api/src/main/java/net/clgd/ccemux/api/config/Group.java
@@ -1,8 +1,10 @@
 package net.clgd.ccemux.api.config;
 
 import java.util.*;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
 import com.google.common.reflect.TypeToken;
 
 /**
@@ -119,7 +121,7 @@ public class Group extends ConfigEntry {
 	 * @param defaultValue The default value of this property.
 	 * @return The newly created property.
 	 * @throws IllegalStateException If an entry with the same key exists.
-	 * @see ConfigProperty#Property(String, TypeToken, Object)
+	 * @see ConfigProperty(String, TypeToken, Object)
 	 */
 	@Nonnull
 	public <T> ConfigProperty<T> property(@Nonnull String key, @Nonnull TypeToken<T> type, T defaultValue) {
@@ -136,7 +138,7 @@ public class Group extends ConfigEntry {
 	 * @param defaultValue The default value of this property.
 	 * @return The newly created property.
 	 * @throws IllegalStateException If an entry with the same key exists.
-	 * @see ConfigProperty#Property(String, Class, Object)
+	 * @see ConfigProperty(String, Class, Object)
 	 */
 	@Nonnull
 	public <T> ConfigProperty<T> property(@Nonnull String key, @Nonnull Class<T> type, T defaultValue) {

--- a/plugin-api/src/main/java/net/clgd/ccemux/api/config/package-info.java
+++ b/plugin-api/src/main/java/net/clgd/ccemux/api/config/package-info.java
@@ -2,9 +2,9 @@
  * This package contains the api for the modular configuration system used by
  * CCEmuX. Any type can be stored, although "basic" types (boxed primitives,
  * strings, lists, etc) should be preferred for compatibility reasons.
- * 
- * @see Config
- * @see ConfigProperty
- * @see Group
+ *
+ * @see net.clgd.ccemux.api.config.Config
+ * @see net.clgd.ccemux.api.config.ConfigProperty
+ * @see net.clgd.ccemux.api.config.Group
  */
 package net.clgd.ccemux.api.config;

--- a/plugin-api/src/main/java/net/clgd/ccemux/api/emulation/EmuConfig.java
+++ b/plugin-api/src/main/java/net/clgd/ccemux/api/emulation/EmuConfig.java
@@ -20,58 +20,58 @@ public abstract class EmuConfig extends Config {
 
 	@Nonnull
 	public ConfigProperty<Double> termScale = property("termScale", double.class, 2.0)
-			.setName("Terminal scale");
-	
+		.setName("Terminal scale");
+
 	@Nonnull
 	public ConfigProperty<Integer> termHeight = property("termHeight", int.class, 19)
-			.setName("Terminal height");
-	
+		.setName("Terminal height");
+
 	@Nonnull
 	public ConfigProperty<Integer> termWidth = property("termWidth", int.class, 51)
-			.setName("Terminal width");
-	
+		.setName("Terminal width");
+
 	@Nonnull
 	public ConfigProperty<String> renderer = property("renderer", String.class, "AWT")
-			.setName("Renderer");
+		.setName("Renderer");
 
 	@Nonnull
 	public ConfigProperty<Long> maxComputerCapacity = property("maxComputerCapacity", long.class, 2L * 1024 * 1024)
-			.setName("Computer space limit")
-			.setDescription("The disk space limit for computers in bytes");
-	
+		.setName("Computer space limit")
+		.setDescription("The disk space limit for computers in bytes");
+
 	@Nonnull
 	public ConfigProperty<Integer> maximumFilesOpen = property("maximumFilesOpen", int.class, 128)
-			.setName("Maximum files open per computer")
-			.setDescription("Set how many files a computer can have open at the same time. Set to 0 for unlimited.");
-	
+		.setName("Maximum files open per computer")
+		.setDescription("Set how many files a computer can have open at the same time. Set to 0 for unlimited.");
+
 	@Nonnull
 	public ConfigProperty<Boolean> httpEnabled = property("httpEnable", boolean.class, true)
-			.setName("Enable HTTP API")
-			.setDescription("Enable the \"http\" API on Computers (see \"httpWhitelist\" and \"httpBlacklist\" for more fine grained control than this)");
-	
+		.setName("Enable HTTP API")
+		.setDescription("Enable the \"http\" API on Computers (see \"httpWhitelist\" and \"httpBlacklist\" for more fine grained control than this)");
+
 	@Nonnull
-	public ConfigProperty<String[]> httpWhitelist = property("httpWhitelist", String[].class, new String[]{"*"})
-			.setName("HTTP whitelist")
-			.setDescription("A list of wildcards for domains or IP ranges that can be accessed through the \"http\" API on Computers.\n" +
-					"Set this to \"*\" to access to the entire internet. Example: \"*.pastebin.com\" will restrict access to just subdomains of pastebin.com.\n" +
-					"You can use domain names (\"pastebin.com\"), wilcards (\"*.pastebin.com\") or CIDR notation (\"127.0.0.0/8\").");
-	
+	public ConfigProperty<String[]> httpWhitelist = property("httpWhitelist", String[].class, new String[] { "*" })
+		.setName("HTTP whitelist")
+		.setDescription("A list of wildcards for domains or IP ranges that can be accessed through the \"http\" API on Computers.\n" +
+			"Set this to \"*\" to access to the entire internet. Example: \"*.pastebin.com\" will restrict access to just subdomains of pastebin.com.\n" +
+			"You can use domain names (\"pastebin.com\"), wilcards (\"*.pastebin.com\") or CIDR notation (\"127.0.0.0/8\").");
+
 	@Nonnull
-	public ConfigProperty<String[]> httpBlacklist = property("httpBlacklist", String[].class, new String[]{"127.0.0.0/8", "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "fd00::/8"})
-			.setName("HTTP blacklist")
-			.setDescription("A list of wildcards for domains or IP ranges that cannot be accessed through the \"http\" API on Computers.\n" +
-					"If this is empty then all whitelisted domains will be accessible. Example: \"*.github.com\" will block access to all subdomains of github.com.\n" +
-					"You can use domain names (\"pastebin.com\"), wilcards (\"*.pastebin.com\") or CIDR notation (\"127.0.0.0/8\").");
-	
+	public ConfigProperty<String[]> httpBlacklist = property("httpBlacklist", String[].class, new String[] { "127.0.0.0/8", "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "fd00::/8" })
+		.setName("HTTP blacklist")
+		.setDescription("A list of wildcards for domains or IP ranges that cannot be accessed through the \"http\" API on Computers.\n" +
+			"If this is empty then all whitelisted domains will be accessible. Example: \"*.github.com\" will block access to all subdomains of github.com.\n" +
+			"You can use domain names (\"pastebin.com\"), wilcards (\"*.pastebin.com\") or CIDR notation (\"127.0.0.0/8\").");
+
 	@Nonnull
 	public ConfigProperty<Boolean> disableLua51Features = property("disableLua51Features", boolean.class, false)
-			.setName("Disable Lua 5.1 features")
-			.setDescription("Set this to true to disable Lua 5.1 functions that will be removed in a future update. Useful for ensuring forward compatibility of your programs now.");
-	
+		.setName("Disable Lua 5.1 features")
+		.setDescription("Set this to true to disable Lua 5.1 functions that will be removed in a future update. Useful for ensuring forward compatibility of your programs now.");
+
 	@Nonnull
 	public ConfigProperty<String> defaultComputerSettings = property("defaultComputerSettings", String.class, "")
-			.setName("Default computer settings")
-			.setDescription("A comma seperated list of default system settings to set on new computers. Example: \"shell.autocomplete=false,lua.autocomplete=false,edit.autocomplete=false\" will disable all autocompletion");
+		.setName("Default computer settings")
+		.setDescription("A comma seperated list of default system settings to set on new computers. Example: \"shell.autocomplete=false,lua.autocomplete=false,edit.autocomplete=false\" will disable all autocompletion");
 
 	public abstract void save() throws IOException;
 

--- a/plugin-api/src/main/java/net/clgd/ccemux/api/emulation/EmulatedComputer.java
+++ b/plugin-api/src/main/java/net/clgd/ccemux/api/emulation/EmulatedComputer.java
@@ -13,57 +13,54 @@ import dan200.computercraft.core.computer.IComputerEnvironment;
 public abstract class EmulatedComputer extends Computer {
 	/**
 	 * A listener that's triggered every time the computer is ticked
-	 *
 	 */
-	public static interface Listener {
+	public interface Listener {
 		/**
 		 * Called when the computer is ticked
 		 */
-		public void onAdvance(double dt);
+		void onAdvance(double dt);
 	}
 
 	/**
 	 * A builder used to specify values for an emulated computer before it's created
 	 */
-	public static interface Builder {
+	public interface Builder {
 
 		/**
-		 * Sets the ID of the computer to construct. Setting the id to <code>null</code>
+		 * Sets the ID of the computer to construct. Setting the id to {@code null}
 		 * (the default value) will result in the ID being automatically chosen by the
 		 * environment.
 		 *
 		 * @return This builder, for chaining
 		 */
 		@Nonnull
-		public Builder id(@Nullable Integer num);
+		Builder id(@Nullable Integer num);
 
 		/**
-		 * Sets the root (<code>/</code>) mount of the computer to construct. Setting
-		 * the root mount to <code>null</code> (the default value) will result in one
+		 * Sets the root ({@code /}) mount of the computer to construct. Setting
+		 * the root mount to {@code null} (the default value) will result in one
 		 * being created by the environment.
 		 *
-		 * @param rootMount
-		 *            The writable mount to use as a root mount
+		 * @param rootMount The writable mount to use as a root mount
 		 * @return This builder, for chaining
 		 */
 		@Nonnull
-		public Builder rootMount(@Nullable IWritableMount rootMount);
+		Builder rootMount(@Nullable IWritableMount rootMount);
 
 		/**
 		 * Sets the label of the computer to construct. Setting the label to
-		 * <code>null</code> (the default value) will result in no label being set.
+		 * {@code null} (the default value) will result in no label being set.
 		 *
 		 * @return This builder, for chaining
 		 */
 		@Nonnull
-		public Builder label(@Nullable String label);
+		Builder label(@Nullable String label);
 
 		/**
 		 * Builds an emulated computer using the given values
 		 */
 		@Nonnull
-		public EmulatedComputer build();
-
+		EmulatedComputer build();
 	}
 
 	/**
@@ -74,7 +71,6 @@ public abstract class EmulatedComputer extends Computer {
 
 	protected EmulatedComputer(@Nonnull IComputerEnvironment environment, @Nonnull EmulatedTerminal terminal, int id) {
 		super(environment, terminal, id);
-
 		this.terminal = terminal;
 	}
 
@@ -85,7 +81,7 @@ public abstract class EmulatedComputer extends Computer {
 
 	/**
 	 * Removes a listener
-	 * 
+	 *
 	 * @see #addListener(Listener)
 	 */
 	public abstract boolean removeListener(@Nonnull Listener l);
@@ -96,8 +92,7 @@ public abstract class EmulatedComputer extends Computer {
 	 * path, with their original name. Directories will be recursively copied into
 	 * the destination in a similar fashion to files.
 	 *
-	 * @param files
-	 *            The files to copy
+	 * @param files The files to copy
 	 */
 	public abstract void copyFiles(@Nonnull Iterable<File> files, @Nonnull String location) throws IOException;
 

--- a/plugin-api/src/main/java/net/clgd/ccemux/api/emulation/EmulatedPalette.java
+++ b/plugin-api/src/main/java/net/clgd/ccemux/api/emulation/EmulatedPalette.java
@@ -34,15 +34,11 @@ public class EmulatedPalette extends Palette {
 
 	/**
 	 * Change a color
-	 * 
-	 * @param i
-	 *            The index of the color
-	 * @param r
-	 *            The red component of the color
-	 * @param g
-	 *            The green component of the color
-	 * @param b
-	 *            The blue component of the color
+	 *
+	 * @param i The index of the color
+	 * @param r The red component of the color
+	 * @param g The green component of the color
+	 * @param b The blue component of the color
 	 */
 	@Override
 	public void setColour(int i, double r, double g, double b) {

--- a/plugin-api/src/main/java/net/clgd/ccemux/api/emulation/EmulatedTerminal.java
+++ b/plugin-api/src/main/java/net/clgd/ccemux/api/emulation/EmulatedTerminal.java
@@ -46,71 +46,81 @@ public class EmulatedTerminal extends Terminal {
 	@Override
 	public void resize(int width, int height) {
 		super.resize(width, height);
-		for (Listener listener : listeners)
+		for (Listener listener : listeners) {
 			listener.resize(width, height);
+		}
 	}
 
 	@Override
 	public void setCursorPos(int x, int y) {
 		super.setCursorPos(x, y);
-		for (Listener listener : listeners)
+		for (Listener listener : listeners) {
 			listener.setCursorPos(x, y);
+		}
 	}
 
 	@Override
 	public void setCursorBlink(boolean blink) {
 		super.setCursorBlink(blink);
-		for (Listener listener : listeners)
+		for (Listener listener : listeners) {
 			listener.setCursorBlink(blink);
+		}
 	}
 
 	@Override
 	public void setTextColour(int colour) {
 		super.setTextColour(colour);
-		for (Listener listener : listeners)
+		for (Listener listener : listeners) {
 			listener.setTextColour(colour);
+		}
 	}
 
 	@Override
 	public void setBackgroundColour(int colour) {
 		super.setBackgroundColour(colour);
-		for (Listener listener : listeners)
+		for (Listener listener : listeners) {
 			listener.setBackgroundColour(colour);
+		}
 	}
 
 	@Override
 	public void blit(@Nonnull String text, @Nonnull String textColour, @Nonnull String backgroundColour) {
 		super.blit(text, textColour, backgroundColour);
-		for (Listener listener : listeners)
+		for (Listener listener : listeners) {
 			listener.blit(text, textColour, backgroundColour);
+		}
 	}
 
 	@Override
 	public void write(@Nonnull String text) {
 		super.write(text);
-		for (Listener listener : listeners)
+		for (Listener listener : listeners) {
 			listener.write(text);
+		}
 	}
 
 	@Override
 	public void scroll(int yDiff) {
 		super.scroll(yDiff);
-		for (Listener listener : listeners)
+		for (Listener listener : listeners) {
 			listener.scroll(yDiff);
+		}
 	}
 
 	@Override
 	public void clear() {
 		super.clear();
-		for (Listener listener : listeners)
+		for (Listener listener : listeners) {
 			listener.clear();
+		}
 	}
 
 	@Override
 	public void clearLine() {
 		super.clearLine();
-		for (Listener listener : listeners)
+		for (Listener listener : listeners) {
 			listener.clearLine();
+		}
 	}
 
 	@Override

--- a/plugin-api/src/main/java/net/clgd/ccemux/api/emulation/Emulator.java
+++ b/plugin-api/src/main/java/net/clgd/ccemux/api/emulation/Emulator.java
@@ -18,13 +18,13 @@ public interface Emulator {
 	 * Gets the version string for this emulator
 	 */
 	@Nonnull
-	public String getEmulatorVersion();
+	String getEmulatorVersion();
 
 	/**
 	 * Gets the renderer factory in use
 	 */
 	@Nonnull
-	public <T extends Renderer> RendererFactory<T> getRendererFactory();
+	<T extends Renderer> RendererFactory<T> getRendererFactory();
 
 	/**
 	 * Get the peripheral factory with the given name
@@ -39,24 +39,23 @@ public interface Emulator {
 	 * Gets the config used by this config
 	 */
 	@Nonnull
-	public EmuConfig getConfig();
+	EmuConfig getConfig();
 
 	/**
 	 * Gets the CC jar file
 	 */
 	@Nonnull
-	public File getCCJar();
+	File getCCJar();
 
 	/**
 	 * Creates and adds a new computer, returning the created instance
 	 *
-	 * @param builderMutator
-	 *            A mutator that is passed the computer builder to make any
-	 *            necessary changes before the computer is built
+	 * @param builderMutator A mutator that is passed the computer builder to make any
+	 *                       necessary changes before the computer is built
 	 * @return The computer instance
 	 */
 	@Nonnull
-	public EmulatedComputer createComputer(@Nonnull Consumer<EmulatedComputer.Builder> builderMutator);
+	EmulatedComputer createComputer(@Nonnull Consumer<EmulatedComputer.Builder> builderMutator);
 
 	/**
 	 * Creates and adds a new computer, returning the created instance
@@ -64,26 +63,26 @@ public interface Emulator {
 	 * @return The computer instance
 	 */
 	@Nonnull
-	public default EmulatedComputer createComputer() {
-		return createComputer(b -> {});
+	default EmulatedComputer createComputer() {
+		return createComputer(b -> {
+		});
 	}
 
 	/**
 	 * Removes the given computer
 	 *
-	 * @param computer
-	 *            The computer to remove
+	 * @param computer The computer to remove
 	 * @return Whether the computer was removed
 	 */
-	public boolean removeComputer(@Nonnull EmulatedComputer computer);
+	boolean removeComputer(@Nonnull EmulatedComputer computer);
 
 	/**
 	 * Whether the emulator is running
 	 */
-	public boolean isRunning();
+	boolean isRunning();
 
 	/**
 	 * Stops the emulator if it's currently running
 	 */
-	public void stop();
+	void stop();
 }

--- a/plugin-api/src/main/java/net/clgd/ccemux/api/emulation/filesystem/VirtualDirectory.java
+++ b/plugin-api/src/main/java/net/clgd/ccemux/api/emulation/filesystem/VirtualDirectory.java
@@ -1,7 +1,10 @@
 package net.clgd.ccemux.api.emulation.filesystem;
 
 import java.nio.file.Path;
-import java.util.*;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -27,8 +30,7 @@ public final class VirtualDirectory extends VirtualMountEntry {
 		 * Adds an entry to the directory being built, creating directories and
 		 * overwriting existing entries as necessary.
 		 *
-		 * @throws IllegalArgumentException
-		 *             Thrown if the given path is invalid
+		 * @throws IllegalArgumentException Thrown if the given path is invalid
 		 */
 		public void addEntry(@Nonnull Path path, @Nonnull VirtualMountEntry entry) {
 			path = path.normalize();
@@ -72,8 +74,7 @@ public final class VirtualDirectory extends VirtualMountEntry {
 	/**
 	 * Creates a new directory
 	 *
-	 * @param children
-	 *            The entries contained in this directory
+	 * @param children The entries contained in this directory
 	 */
 	public VirtualDirectory(@Nonnull Map<String, VirtualMountEntry> children) {
 		this.children = children;

--- a/plugin-api/src/main/java/net/clgd/ccemux/api/emulation/filesystem/VirtualMount.java
+++ b/plugin-api/src/main/java/net/clgd/ccemux/api/emulation/filesystem/VirtualMount.java
@@ -1,6 +1,8 @@
 package net.clgd.ccemux.api.emulation.filesystem;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
@@ -13,18 +15,18 @@ import dan200.computercraft.api.filesystem.IMount;
 /**
  * An immutable, in-memory {@link dan200.computercraft.api.filesystem.IMount
  * IMount} implementation.
- * 
+ *
  * @author apemanzilla
  */
 public class VirtualMount implements IMount {
 	private final VirtualDirectory root;
 
 	/**
-	 * Constructs a new <code>VirtualMount</code> with the given
+	 * Constructs a new {@link VirtualMount} with the given
 	 * {@link net.clgd.ccemux.api.emulation.filesystem.VirtualDirectory
 	 * VirtualDirectory} as its root folder.
-	 * 
-	 * @param root
+	 *
+	 * @param root The root directory for this virtual mount
 	 */
 	public VirtualMount(@Nonnull VirtualDirectory root) {
 		this.root = root;
@@ -33,13 +35,12 @@ public class VirtualMount implements IMount {
 	/**
 	 * Follows the given path to get a
 	 * {@link net.clgd.ccemux.api.emulation.filesystem.VirtualMountEntry
-	 * MountEntry}. Returns <code>null</code> if the path is invalid (e.g.
+	 * MountEntry}. Returns {@code null} if the path is invalid (e.g.
 	 * non-existent entry or trying to get child of a directory)
-	 * 
-	 * @param path
-	 *            The path to follow
-	 * @return The entry at the given path, or <code>null</code> if the path is
-	 *         invalid
+	 *
+	 * @param path The path to follow
+	 * @return The entry at the given path, or {@code null} if the path is
+	 * invalid
 	 */
 	@Nullable
 	public VirtualMountEntry follow(@Nonnull Path path) {

--- a/plugin-api/src/main/java/net/clgd/ccemux/api/emulation/filesystem/VirtualMountEntry.java
+++ b/plugin-api/src/main/java/net/clgd/ccemux/api/emulation/filesystem/VirtualMountEntry.java
@@ -3,9 +3,8 @@ package net.clgd.ccemux.api.emulation.filesystem;
 /**
  * A base type for {@link VirtualFile} and {@link VirtualDirectory}, used by
  * {@link VirtualMount}. Should not be extended by external code.
- * 
- * @author apemanzilla
  *
+ * @author apemanzilla
  */
 public abstract class VirtualMountEntry {
 	VirtualMountEntry() {}

--- a/plugin-api/src/main/java/net/clgd/ccemux/api/emulation/filesystem/package-info.java
+++ b/plugin-api/src/main/java/net/clgd/ccemux/api/emulation/filesystem/package-info.java
@@ -1,8 +1,8 @@
 /**
  * Contains classes used for emulating filesystem interaction with CC
- * 
- * @see VirtualMount
- * @see VirtualDirectory
- * @see VirtualFile
+ *
+ * @see net.clgd.ccemux.api.emulation.filesystem.VirtualMount
+ * @see net.clgd.ccemux.api.emulation.filesystem.VirtualDirectory
+ * @see net.clgd.ccemux.api.emulation.filesystem.VirtualFile
  */
 package net.clgd.ccemux.api.emulation.filesystem;

--- a/plugin-api/src/main/java/net/clgd/ccemux/api/plugins/Plugin.java
+++ b/plugin-api/src/main/java/net/clgd/ccemux/api/plugins/Plugin.java
@@ -38,7 +38,7 @@ public abstract class Plugin {
 	 * Gets all the hooks this plugin has registered of a specific type
 	 *
 	 * @param cls The type
-	 * @return
+	 * @return A set of all hooks of the given type
 	 */
 	@SuppressWarnings("unchecked")
 	@Nonnull
@@ -57,10 +57,9 @@ public abstract class Plugin {
 	}
 
 	/**
-	 * Registers a new hook which may be called later. The <code>cls</code>
+	 * Registers a new hook which may be called later. The {@code cls}
 	 * parameter is only used to help out with type inference so that lambdas
-	 * can be used.<br />
-	 * <br />
+	 * can be used.
 	 *
 	 * @deprecated Using this method with lambdas as opposed to
 	 * {@link #registerHook(Hook)} with anonymous classes may cause
@@ -89,13 +88,13 @@ public abstract class Plugin {
 
 	/**
 	 * The version of the plugin. Format does not matter, but semantic
-	 * versioning is recommended - e.g. <code>"1.2.3-alpha"</code>
+	 * versioning is recommended - e.g. {@code "1.2.3-alpha"}.
 	 */
 	@Nonnull
 	public abstract Optional<String> getVersion();
 
 	/**
-	 * The authors of the plugin. If an empty <code>Collection</code> is returned,
+	 * The authors of the plugin. If an empty {@link Collection} is returned,
 	 * no authors will be shown to end-users.
 	 */
 	@Nonnull
@@ -104,7 +103,7 @@ public abstract class Plugin {
 	/**
 	 * Gets the website for this plugin. This can be a link to a forum thread, a
 	 * wiki, source code, or anything else that may be helpful to end-users. If
-	 * an empty <code>Optional</code> is returned, no website will be shown to
+	 * an empty {@link Optional} is returned, no website will be shown to
 	 * end-users.
 	 */
 	@Nonnull
@@ -141,7 +140,7 @@ public abstract class Plugin {
 	/**
 	 * Attempts to locate the file that this plugin was loaded from
 	 *
-	 * @return
+	 * @return The file that this plugin is declared in
 	 */
 	@Nonnull
 	public final Optional<File> getSource() {

--- a/plugin-api/src/main/java/net/clgd/ccemux/api/plugins/hooks/Closing.java
+++ b/plugin-api/src/main/java/net/clgd/ccemux/api/plugins/hooks/Closing.java
@@ -7,11 +7,11 @@ import net.clgd.ccemux.api.emulation.Emulator;
 /**
  * This hook is called when CCEmuX is closing, after all computers have been
  * removed and emulation has stopped. It can be used to free resources.
- * 
+ *
  * @author apemanzilla
  * @see InitializationCompleted
  */
 @FunctionalInterface
 public interface Closing extends Hook {
-	public void onClosing(@Nonnull Emulator emu);
+	void onClosing(@Nonnull Emulator emu);
 }

--- a/plugin-api/src/main/java/net/clgd/ccemux/api/plugins/hooks/ComputerCreated.java
+++ b/plugin-api/src/main/java/net/clgd/ccemux/api/plugins/hooks/ComputerCreated.java
@@ -11,7 +11,7 @@ import net.clgd.ccemux.api.rendering.Renderer;
  * but before it is started or emulated. This hook is invoked before any
  * {@link Renderer} instances are created. This hook can be used to add Lua
  * APIs, for example.
- * 
+ *
  * @author apemanzilla
  * @see CreatingComputer
  * @see RendererCreated
@@ -19,5 +19,5 @@ import net.clgd.ccemux.api.rendering.Renderer;
  */
 @FunctionalInterface
 public interface ComputerCreated extends Hook {
-	public void onComputerCreated(@Nonnull Emulator emu, @Nonnull EmulatedComputer computer);
+	void onComputerCreated(@Nonnull Emulator emu, @Nonnull EmulatedComputer computer);
 }

--- a/plugin-api/src/main/java/net/clgd/ccemux/api/plugins/hooks/ComputerRemoved.java
+++ b/plugin-api/src/main/java/net/clgd/ccemux/api/plugins/hooks/ComputerRemoved.java
@@ -7,7 +7,7 @@ import net.clgd.ccemux.api.emulation.Emulator;
 
 /**
  * This hook is called after a computer has been removed from emulation.
- * 
+ *
  * @author apemanzilla
  * @see CreatingComputer
  * @see ComputerCreated
@@ -15,5 +15,5 @@ import net.clgd.ccemux.api.emulation.Emulator;
  */
 @FunctionalInterface
 public interface ComputerRemoved extends Hook {
-	public void onComputerRemoved(@Nonnull Emulator emu, @Nonnull EmulatedComputer computer);
+	void onComputerRemoved(@Nonnull Emulator emu, @Nonnull EmulatedComputer computer);
 }

--- a/plugin-api/src/main/java/net/clgd/ccemux/api/plugins/hooks/CreatingComputer.java
+++ b/plugin-api/src/main/java/net/clgd/ccemux/api/plugins/hooks/CreatingComputer.java
@@ -11,7 +11,7 @@ import net.clgd.ccemux.api.emulation.Emulator;
  * construction of the emulated computer, so the {@link EmulatedComputer.Builder
  * Builder} will not be modified by CCEmuX - but it may be modified by other
  * plugins which also use this hook.
- * 
+ *
  * @author apemanzilla
  * @see ComputerCreated
  * @see RendererCreated
@@ -19,5 +19,5 @@ import net.clgd.ccemux.api.emulation.Emulator;
  */
 @FunctionalInterface
 public interface CreatingComputer extends Hook {
-	public void onCreatingComputer(@Nonnull Emulator emu, @Nonnull EmulatedComputer.Builder builder);
+	void onCreatingComputer(@Nonnull Emulator emu, @Nonnull EmulatedComputer.Builder builder);
 }

--- a/plugin-api/src/main/java/net/clgd/ccemux/api/plugins/hooks/CreatingROM.java
+++ b/plugin-api/src/main/java/net/clgd/ccemux/api/plugins/hooks/CreatingROM.java
@@ -11,11 +11,11 @@ import net.clgd.ccemux.api.emulation.filesystem.VirtualMountEntry;
 /**
  * Called when CCEmuX creates the ROM for computers. This hook allows plugins to
  * add their own ROM entries, using {@link VirtualDirectory.Builder}.
- * 
+ *
  * @author apemanzilla
  * @see VirtualDirectory.Builder#addEntry(Path, VirtualMountEntry)
  */
 @FunctionalInterface
 public interface CreatingROM extends Hook {
-	public void onCreatingROM(@Nonnull Emulator emu, @Nonnull VirtualDirectory.Builder romBuilder);
+	void onCreatingROM(@Nonnull Emulator emu, @Nonnull VirtualDirectory.Builder romBuilder);
 }

--- a/plugin-api/src/main/java/net/clgd/ccemux/api/plugins/hooks/Hook.java
+++ b/plugin-api/src/main/java/net/clgd/ccemux/api/plugins/hooks/Hook.java
@@ -7,8 +7,8 @@ import net.clgd.ccemux.api.rendering.Renderer;
  * CCEmuX plugins can register hooks - callbacks that are called when various
  * events occur. This interface is merely a common super interface and contains
  * no members, instead child interfaces should be used from the
- * {@link net.clgd.ccemux.api.plugins.hooks} package.<br />
- * <br />
+ * {@link net.clgd.ccemux.api.plugins.hooks} package.
+ *
  * In approximate chronological order, here is a list of some common hooks:
  * <ul>
  * <li>{@link InitializationCompleted} - CCEmuX has finished startup tasks</li>
@@ -25,8 +25,7 @@ import net.clgd.ccemux.api.rendering.Renderer;
  * <li>{@link Closing} - All {@link EmulatedComputer} instances have been
  * removed and CCEmuX is closing</li>
  * </ul>
- * 
- * @author apemanzilla
  *
+ * @author apemanzilla
  */
 public interface Hook {}

--- a/plugin-api/src/main/java/net/clgd/ccemux/api/plugins/hooks/InitializationCompleted.java
+++ b/plugin-api/src/main/java/net/clgd/ccemux/api/plugins/hooks/InitializationCompleted.java
@@ -1,15 +1,17 @@
 package net.clgd.ccemux.api.plugins.hooks;
 
+import net.clgd.ccemux.api.plugins.PluginManager;
+
 /**
  * This hook is called when CCEmuX has finished initialization - after CC has
  * been loaded, but before any computers have been created. This hook should be
  * used to perform setup tasks that require interaction with CC code.
- * 
+ *
  * @author apemanzilla
  * @see Closing
- * @see net.clgd.ccemux.api.plugins.Plugin#setup() Plugin.setup()
+ * @see net.clgd.ccemux.api.plugins.Plugin#setup(PluginManager)
  */
 @FunctionalInterface
 public interface InitializationCompleted extends Hook {
-	public void onInitializationCompleted();
+	void onInitializationCompleted();
 }

--- a/plugin-api/src/main/java/net/clgd/ccemux/api/plugins/hooks/RendererCreated.java
+++ b/plugin-api/src/main/java/net/clgd/ccemux/api/plugins/hooks/RendererCreated.java
@@ -7,7 +7,7 @@ import net.clgd.ccemux.api.rendering.Renderer;
 
 /**
  * Called immediately after a {@link Renderer} is created.
- * 
+ *
  * @author apemanzilla
  * @see CreatingComputer
  * @see ComputerCreated
@@ -15,5 +15,5 @@ import net.clgd.ccemux.api.rendering.Renderer;
  */
 @FunctionalInterface
 public interface RendererCreated extends Hook {
-	public void onRendererCreated(@Nonnull Emulator emu, @Nonnull Renderer renderer);
+	void onRendererCreated(@Nonnull Emulator emu, @Nonnull Renderer renderer);
 }

--- a/plugin-api/src/main/java/net/clgd/ccemux/api/plugins/hooks/Tick.java
+++ b/plugin-api/src/main/java/net/clgd/ccemux/api/plugins/hooks/Tick.java
@@ -9,11 +9,10 @@ import net.clgd.ccemux.api.emulation.Emulator;
  * - 20 times per second, assuming the (real) computer is fast enough. This hook
  * is not recommended unless you have no other option, because it will have a
  * significant impact on performance.
- * 
- * @author apemanzilla
  *
+ * @author apemanzilla
  */
 @FunctionalInterface
 public interface Tick extends Hook {
-	public void onTick(@Nonnull Emulator emu, double dt);
+	void onTick(@Nonnull Emulator emu, double dt);
 }

--- a/plugin-api/src/main/java/net/clgd/ccemux/api/plugins/hooks/package-info.java
+++ b/plugin-api/src/main/java/net/clgd/ccemux/api/plugins/hooks/package-info.java
@@ -1,8 +1,8 @@
-
 /**
  * This package contains various hooks which can be implemented by CCEmuX
  * plugins to provide functionality. A list of common hooks can be
  * found {@link net.clgd.ccemux.api.plugins.hooks.Hook here}.
+ *
  * @see net.clgd.ccemux.api.plugins.hooks.Hook
  */
 package net.clgd.ccemux.api.plugins.hooks;

--- a/plugin-api/src/main/java/net/clgd/ccemux/api/rendering/PaletteAdapter.java
+++ b/plugin-api/src/main/java/net/clgd/ccemux/api/rendering/PaletteAdapter.java
@@ -9,29 +9,26 @@ import net.clgd.ccemux.api.Utils;
  * Wraps a {@link Palette} object with a given {@link ColorAdapter} to make it
  * easier to get color objects from the palette
  *
- * @author apemanzilla
- *
  * @param <C>
+ * @author apemanzilla
  */
 public final class PaletteAdapter<C> {
 
 	/**
 	 * An adapter used to generate a color object from RGB values
 	 *
+	 * @param <T> The type of object created
 	 * @author apemanzilla
-	 *
-	 * @param <T>
-	 *            The type of object created
 	 */
 	@FunctionalInterface
-	public static interface ColorAdapter<T> {
+	public interface ColorAdapter<T> {
 		/**
 		 * Creates a color object from the given RGB values, doubles on the range [0, 1]
 		 *
-		 * @param r
-		 * @param g
-		 * @param b
-		 * @return
+		 * @param r The intensity of the red channel, between 0 and 1.
+		 * @param g The intensity of the green channel, between 0 and 1.
+		 * @param b The intensity of the blue channel, between 0 and 1.
+		 * @return The converted color.
 		 */
 		T rgb(double r, double g, double b);
 	}
@@ -40,13 +37,12 @@ public final class PaletteAdapter<C> {
 	private final ColorAdapter<C> adapter;
 
 	/**
-	 * Creates a color object using the given RGB values (Equivalent to
-	 * <code>getAdapter().rgb(r,g,b)</code>)
+	 * Creates a color object using the given RGB values (Equivalent to {@code getAdapter().rgb(r,g,b)}
 	 *
-	 * @param r
-	 * @param g
-	 * @param b
-	 * @return
+	 * @param r The intensity of the red channel, between 0 and 1.
+	 * @param g The intensity of the green channel, between 0 and 1.
+	 * @param b The intensity of the clue channel, between 0 and 1.
+	 * @return The converted color.
 	 */
 	public C getColor(double r, double g, double b) {
 		return adapter.rgb(r, g, b);
@@ -55,8 +51,8 @@ public final class PaletteAdapter<C> {
 	/**
 	 * Creates a color object using the given color from the palette
 	 *
-	 * @param c
-	 * @return
+	 * @param c The numeric index of the terminal color
+	 * @return The converted color
 	 */
 	public C getColor(int c) {
 		double[] col;
@@ -70,8 +66,8 @@ public final class PaletteAdapter<C> {
 	/**
 	 * Creates a color object using the given color from the palette
 	 *
-	 * @param c
-	 * @return
+	 * @param c A hexadecimal terminal color
+	 * @return The converted color
 	 */
 	public C getColor(char c) {
 		return getColor(Utils.base16ToInt(c));

--- a/plugin-api/src/main/java/net/clgd/ccemux/api/rendering/Renderer.java
+++ b/plugin-api/src/main/java/net/clgd/ccemux/api/rendering/Renderer.java
@@ -42,5 +42,5 @@ public interface Renderer extends EmulatedComputer.Listener {
 	void removeListener(@Nonnull Listener l);
 
 	@Override
-	public default void onAdvance(double dt) {}
+	default void onAdvance(double dt) {}
 }

--- a/plugin-api/src/main/java/net/clgd/ccemux/api/rendering/RendererFactory.java
+++ b/plugin-api/src/main/java/net/clgd/ccemux/api/rendering/RendererFactory.java
@@ -8,25 +8,23 @@ import net.clgd.ccemux.api.emulation.EmulatedComputer;
 /**
  * A factory used to create a renderer for a given computer
  *
- * @param <T>
- *            The type of renderer created by this factory
+ * @param <T> The type of renderer created by this factory
  */
 @FunctionalInterface
 public interface RendererFactory<T extends Renderer> {
 	/**
 	 * Creates a renderer for the given computer and config
 	 */
-	public T create(@Nonnull EmulatedComputer computer, @Nonnull EmuConfig cfg);
+	T create(@Nonnull EmulatedComputer computer, @Nonnull EmuConfig cfg);
 
 	/**
 	 * Creates a config editor window for the given config. Returns true if
-	 * successful. If unsuccesful or unsupported, <code>false</code> should be
-	 * returned.<br>
-	 * <br>
+	 * successful. If unsuccesful or unsupported, {@code false} should be
+	 * returned.
+	 *
 	 * The default implementation returns false and has no side effects.
 	 *
-	 * @param config
-	 *            The config to let the user edit
+	 * @param config The config to let the user edit
 	 * @return Whether an editor window was opened
 	 */
 	default boolean createConfigEditor(@Nonnull EmuConfig config) {

--- a/src/main/java/net/clgd/ccemux/emulation/CCEmuX.java
+++ b/src/main/java/net/clgd/ccemux/emulation/CCEmuX.java
@@ -7,6 +7,8 @@ import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 
+import javax.annotation.Nonnull;
+
 import dan200.computercraft.ComputerCraft;
 import dan200.computercraft.api.filesystem.IMount;
 import dan200.computercraft.api.filesystem.IWritableMount;
@@ -59,23 +61,26 @@ public class CCEmuX implements Runnable, Emulator, IComputerEnvironment {
 	private long started = -1;
 	private boolean running;
 
+	@Nonnull
 	@Override
 	public EmuConfig getConfig() {
 		return cfg;
 	}
 
+	@Nonnull
 	@Override
 	public File getCCJar() {
 		return ccSource;
 	}
 
+	@Nonnull
 	@Override
 	public String getEmulatorVersion() {
 		return getVersion();
 	}
 
 	@Override
-	public PeripheralFactory<?> getPeripheralFactory(String name) {
+	public PeripheralFactory<?> getPeripheralFactory(@Nonnull String name) {
 		return pluginMgr.getPeripherals().get(name);
 	}
 
@@ -87,6 +92,7 @@ public class CCEmuX implements Runnable, Emulator, IComputerEnvironment {
 	 *
 	 * @return The new computer
 	 */
+	@Nonnull
 	public EmulatedComputer createComputer() {
 		return createComputer(b -> {});
 	}
@@ -101,7 +107,8 @@ public class CCEmuX implements Runnable, Emulator, IComputerEnvironment {
 	 *            Will be called after plugin hooks with the builder
 	 * @return The new computer
 	 */
-	public EmulatedComputer createComputer(Consumer<EmulatedComputer.Builder> builderMutator) {
+	@Nonnull
+	public EmulatedComputer createComputer(@Nonnull Consumer<EmulatedComputer.Builder> builderMutator) {
 		val term = new EmulatedTerminal(cfg.termWidth.get(), cfg.termHeight.get());
 		val builder = EmulatedComputerImpl.builder(this, term).id(-1);
 
@@ -133,7 +140,7 @@ public class CCEmuX implements Runnable, Emulator, IComputerEnvironment {
 		ec.turnOn();
 	}
 
-	public boolean removeComputer(EmulatedComputer computer) {
+	public boolean removeComputer(@Nonnull EmulatedComputer computer) {
 		synchronized (computers) {
 			try {
 				log.info("Removing computer ID {}", computer.getID());
@@ -190,7 +197,7 @@ public class CCEmuX implements Runnable, Emulator, IComputerEnvironment {
 
 			try {
 				Thread.sleep(Math.max(0, 50 - (System.currentTimeMillis() - now)));
-			} catch (InterruptedException e) {}
+			} catch (InterruptedException ignored) {}
 		}
 
 		log.info("Emulation stopped");

--- a/src/main/java/net/clgd/ccemux/emulation/EmulatedComputerImpl.java
+++ b/src/main/java/net/clgd/ccemux/emulation/EmulatedComputerImpl.java
@@ -8,6 +8,8 @@ import java.util.Arrays;
 import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+import javax.annotation.Nonnull;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 
@@ -21,7 +23,6 @@ import net.clgd.ccemux.api.emulation.EmulatedTerminal;
 
 /**
  * Represents a computer that can be emulated via CCEmuX
- *
  */
 @Slf4j
 public class EmulatedComputerImpl extends EmulatedComputer {
@@ -42,10 +43,9 @@ public class EmulatedComputerImpl extends EmulatedComputer {
 	}
 
 	/**
-	 * A class used to create new <code>EmulatedComputer</code> instances
+	 * A class used to create new {@link EmulatedComputer} instances
 	 *
 	 * @author apemanzilla
-	 *
 	 */
 	public static class BuilderImpl implements Builder {
 		private final IComputerEnvironment env;
@@ -69,6 +69,7 @@ public class EmulatedComputerImpl extends EmulatedComputer {
 		 *
 		 * @see net.clgd.ccemux.emulation.Builder#id(java.lang.Integer)
 		 */
+		@Nonnull
 		@Override
 		public BuilderImpl id(Integer num) {
 			id = num;
@@ -81,6 +82,7 @@ public class EmulatedComputerImpl extends EmulatedComputer {
 		 * @see net.clgd.ccemux.emulation.Builder#rootMount(dan200.computercraft.api.
 		 * filesystem.IWritableMount)
 		 */
+		@Nonnull
 		@Override
 		public Builder rootMount(IWritableMount rootMount) {
 			this.rootMount = rootMount;
@@ -92,6 +94,7 @@ public class EmulatedComputerImpl extends EmulatedComputer {
 		 *
 		 * @see net.clgd.ccemux.emulation.Builder#label(java.lang.String)
 		 */
+		@Nonnull
 		@Override
 		public Builder label(String label) {
 			this.label = label;
@@ -103,14 +106,16 @@ public class EmulatedComputerImpl extends EmulatedComputer {
 		 *
 		 * @see net.clgd.ccemux.emulation.Builder#build()
 		 */
+		@Nonnull
 		@Override
 		public EmulatedComputer build() {
 			if (!built) {
 				EmulatedComputer ec = new EmulatedComputerImpl(env, term, Optional.ofNullable(id).orElse(-1));
 				ec.assignID();
 
-				if (label != null)
+				if (label != null) {
 					ec.setLabel(label);
+				}
 
 				try {
 					if (rootMount != null) {
@@ -130,18 +135,18 @@ public class EmulatedComputerImpl extends EmulatedComputer {
 	}
 
 	/**
-	 * Gets a new builder to create an <code>EmulatedComputer</code> instance
+	 * Gets a new builder to create an {@link EmulatedComputer} instance.
 	 *
-	 * @return
+	 * @return The new builder
 	 */
 	public static Builder builder(IComputerEnvironment env, EmulatedTerminal term) {
 		return new BuilderImpl(env, term);
 	}
 
 	/**
-	 * The <code>EmulatedTerminal</code> that this computer draws to
+	 * The terminal that this computer draws to
 	 */
-	public final EmulatedTerminal terminal;
+	private final EmulatedTerminal terminal;
 
 	private final CopyOnWriteArrayList<Listener> listeners = new CopyOnWriteArrayList<>();
 
@@ -151,12 +156,12 @@ public class EmulatedComputerImpl extends EmulatedComputer {
 	}
 
 	@Override
-	public boolean addListener(Listener l) {
+	public boolean addListener(@Nonnull Listener l) {
 		return listeners.add(l);
 	}
 
 	@Override
-	public boolean removeListener(Listener l) {
+	public boolean removeListener(@Nonnull Listener l) {
 		return listeners.remove(l);
 	}
 
@@ -164,7 +169,7 @@ public class EmulatedComputerImpl extends EmulatedComputer {
 	public void advance(double dt) {
 		super.advance(dt);
 
-		for(int i = 0; i < 6; i++) {
+		for (int i = 0; i < 6; i++) {
 			IPeripheral peripheral = getPeripheral(i);
 			if (peripheral instanceof Listener) ((Listener) peripheral).onAdvance(dt);
 		}
@@ -173,7 +178,7 @@ public class EmulatedComputerImpl extends EmulatedComputer {
 	}
 
 	@Override
-	public void copyFiles(Iterable<File> files, String location) throws IOException {
+	public void copyFiles(@Nonnull Iterable<File> files, @Nonnull String location) throws IOException {
 		val mount = this.getRootMount();
 		val base = Paths.get(location);
 
@@ -181,8 +186,9 @@ public class EmulatedComputerImpl extends EmulatedComputer {
 			val path = base.resolve(f.getName()).toString();
 
 			if (f.isFile()) {
-				if (f.length() > mount.getRemainingSpace())
+				if (f.length() > mount.getRemainingSpace()) {
 					throw new IOException("Not enough space on computer");
+				}
 
 				val s = mount.openForWrite(path);
 				IOUtils.copy(FileUtils.openInputStream(f), s);

--- a/src/main/java/net/clgd/ccemux/init/Launcher.java
+++ b/src/main/java/net/clgd/ccemux/init/Launcher.java
@@ -39,16 +39,16 @@ public class Launcher {
 		opts.addOption(builder("h").longOpt("help").desc("Shows this help information").build());
 
 		opts.addOption(builder("d").longOpt("data-dir")
-				.desc("Sets the data directory where plugins, configs, and other data are stored.").hasArg()
-				.argName("path").build());
+			.desc("Sets the data directory where plugins, configs, and other data are stored.").hasArg()
+			.argName("path").build());
 
 		opts.addOption(builder("r").longOpt("renderer")
-				.desc("Sets the renderer to use. Run without a value to list all available renderers.").hasArg()
-				.optionalArg(true).argName("renderer").build());
+			.desc("Sets the renderer to use. Run without a value to list all available renderers.").hasArg()
+			.optionalArg(true).argName("renderer").build());
 
 		opts.addOption(builder().longOpt("plugin").desc(
-				"Used to load additional plugins not present in the default plugin directory. Value should be a path to a .jar file.")
-				.hasArg().argName("file").build());
+			"Used to load additional plugins not present in the default plugin directory. Value should be a path to a .jar file.")
+			.hasArg().argName("file").build());
 	}
 
 	private static void printHelp() {
@@ -107,9 +107,9 @@ public class Launcher {
 			scrollPane.setMaximumSize(new Dimension(600, 400));
 
 			int result = JOptionPane.showConfirmDialog(null,
-					new Object[]{"CCEmuX has crashed!", scrollPane,
-							"Would you like to create a bug report on GitHub?"},
-					"CCEmuX Crash", JOptionPane.YES_NO_OPTION, JOptionPane.ERROR_MESSAGE);
+				new Object[] { "CCEmuX has crashed!", scrollPane,
+					"Would you like to create a bug report on GitHub?" },
+				"CCEmuX Crash", JOptionPane.YES_NO_OPTION, JOptionPane.ERROR_MESSAGE);
 
 			if (result == JOptionPane.YES_OPTION) {
 				try {
@@ -124,19 +124,16 @@ public class Launcher {
 	private void setSystemLAF() {
 		try {
 			UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
-		} catch (ClassNotFoundException | InstantiationException | IllegalAccessException
-				| UnsupportedLookAndFeelException e) {
+		} catch (ClassNotFoundException | InstantiationException | IllegalAccessException | UnsupportedLookAndFeelException e) {
 			log.warn("Failed to set system look and feel", e);
 		}
 	}
 
-	private ClassLoader buildLoader() throws ReflectiveOperationException {
+	private ClassLoader buildLoader() {
 		File pd = dataDir.resolve("plugins").toFile();
 
-		if (pd.isFile())
-			pd.delete();
-		if (!pd.exists())
-			pd.mkdirs();
+		if (pd.isFile()) pd.delete();
+		if (!pd.exists()) pd.mkdirs();
 
 		HashSet<URL> urls = new HashSet<>();
 
@@ -168,12 +165,13 @@ public class Launcher {
 
 	private File getCCSource() throws URISyntaxException {
 		URI source = Optional.ofNullable(ComputerCraft.class.getProtectionDomain().getCodeSource())
-				.orElseThrow(() -> new IllegalStateException("Cannot locate CC")).getLocation().toURI();
+			.orElseThrow(() -> new IllegalStateException("Cannot locate CC")).getLocation().toURI();
 
 		log.debug("CC is loaded from {}", source);
 
-		if (!source.getScheme().equals("file"))
+		if (!source.getScheme().equals("file")) {
 			throw new IllegalStateException("Incompatible CC location: " + source.toString());
+		}
 
 		return new File(source);
 	}
@@ -194,8 +192,9 @@ public class Launcher {
 			}
 			log.debug("Config: {}", cfg);
 
-			if (cfg.termScale.get() != cfg.termScale.get().intValue())
+			if (cfg.termScale.get() != cfg.termScale.get().intValue()) {
 				log.warn("Terminal scale is not an integer - stuff might look bad! Don't blame us!");
+			}
 
 			PluginManager pluginMgr = new PluginManager(cfg);
 			pluginMgr.gatherCandidates(buildLoader());
@@ -230,9 +229,9 @@ public class Launcher {
 
 				if (!GraphicsEnvironment.isHeadless()) {
 					JOptionPane.showMessageDialog(null,
-							"Specified renderer '" + renderer + "' does not exist.\n"
-									+ "Please double check your config file and plugin list.",
-							"Configuration Error", JOptionPane.ERROR_MESSAGE);
+						"Specified renderer '" + renderer + "' does not exist.\n"
+							+ "Please double check your config file and plugin list.",
+						"Configuration Error", JOptionPane.ERROR_MESSAGE);
 				}
 
 				System.exit(1);
@@ -242,8 +241,9 @@ public class Launcher {
 
 			log.info("Setting up emulation environment");
 
-			if (!GraphicsEnvironment.isHeadless())
+			if (!GraphicsEnvironment.isHeadless()) {
 				Optional.ofNullable(SplashScreen.getSplashScreen()).ifPresent(SplashScreen::close);
+			}
 
 			TerminalFont.loadImplicitFonts(getClass().getClassLoader());
 

--- a/src/main/java/net/clgd/ccemux/plugins/PluginManager.java
+++ b/src/main/java/net/clgd/ccemux/plugins/PluginManager.java
@@ -4,6 +4,8 @@ import java.io.File;
 import java.util.*;
 import java.util.function.Consumer;
 
+import javax.annotation.Nonnull;
+
 import com.google.common.base.Preconditions;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
@@ -98,52 +100,53 @@ public class PluginManager implements Closing, CreatingComputer, CreatingROM, Co
 	}
 
 	@Override
-	public void onTick(Emulator emu, double dt) {
+	public void onTick(@Nonnull Emulator emu, double dt) {
 		doHooks(Tick.class, h -> h.onTick(emu, dt));
 	}
 
 	@Override
-	public void onRendererCreated(Emulator emu, Renderer renderer) {
+	public void onRendererCreated(@Nonnull Emulator emu, @Nonnull Renderer renderer) {
 		doHooks(RendererCreated.class, h -> h.onRendererCreated(emu, renderer));
 	}
 
 	@Override
 	public void onInitializationCompleted() {
-		doHooks(InitializationCompleted.class, h -> h.onInitializationCompleted());
+		doHooks(InitializationCompleted.class, InitializationCompleted::onInitializationCompleted);
 	}
 
 	@Override
-	public void onComputerRemoved(Emulator emu, EmulatedComputer computer) {
+	public void onComputerRemoved(@Nonnull Emulator emu, @Nonnull EmulatedComputer computer) {
 		doHooks(ComputerRemoved.class, h -> h.onComputerRemoved(emu, computer));
 	}
 
 	@Override
-	public void onComputerCreated(Emulator emu, EmulatedComputer computer) {
+	public void onComputerCreated(@Nonnull Emulator emu, @Nonnull EmulatedComputer computer) {
 		doHooks(ComputerCreated.class, h -> h.onComputerCreated(emu, computer));
 	}
 
 	@Override
-	public void onCreatingComputer(Emulator emu, Builder builder) {
+	public void onCreatingComputer(@Nonnull Emulator emu, @Nonnull Builder builder) {
 		doHooks(CreatingComputer.class, h -> h.onCreatingComputer(emu, builder));
 	}
 
 	@Override
-	public void onClosing(Emulator emu) {
+	public void onClosing(@Nonnull Emulator emu) {
 		doHooks(Closing.class, h -> h.onClosing(emu));
 	}
 
 	@Override
-	public void onCreatingROM(Emulator emu, VirtualDirectory.Builder romBuilder) {
+	public void onCreatingROM(@Nonnull Emulator emu, @Nonnull VirtualDirectory.Builder romBuilder) {
 		doHooks(CreatingROM.class, h -> h.onCreatingROM(emu, romBuilder));
 	}
 
+	@Nonnull
 	@Override
 	public EmuConfig config() {
 		return cfg;
 	}
 
 	@Override
-	public void addRenderer(String name, RendererFactory<?> factory) {
+	public void addRenderer(@Nonnull String name, @Nonnull RendererFactory<?> factory) {
 		Preconditions.checkNotNull(name, "name cannot be null");
 		Preconditions.checkNotNull(factory, "factory cannot be null");
 
@@ -155,7 +158,7 @@ public class PluginManager implements Closing, CreatingComputer, CreatingROM, Co
 	}
 
 	@Override
-	public void addPeripheral(String name, PeripheralFactory<?> factory) {
+	public void addPeripheral(@Nonnull String name, @Nonnull PeripheralFactory<?> factory) {
 		Preconditions.checkNotNull(name, "name cannot be null");
 		Preconditions.checkNotNull(factory, "factory cannot be null");
 

--- a/src/main/java/net/clgd/ccemux/plugins/builtin/AWTPlugin.java
+++ b/src/main/java/net/clgd/ccemux/plugins/builtin/AWTPlugin.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
 
+import javax.annotation.Nonnull;
 import javax.swing.JFrame;
 
 import com.google.auto.service.AutoService;
@@ -24,48 +25,53 @@ import net.clgd.ccemux.rendering.awt.config.ConfigView;
 public class AWTPlugin extends Plugin {
 	private AWTConfig config;
 
+	@Nonnull
 	@Override
 	public String getName() {
 		return "AWT Renderer";
 	}
 
+	@Nonnull
 	@Override
 	public String getDescription() {
 		return "A CPU-based renderer using Java AWT.";
 	}
 
+	@Nonnull
 	@Override
 	public Optional<String> getVersion() {
 		return Optional.empty();
 	}
 
+	@Nonnull
 	@Override
 	public Collection<String> getAuthors() {
 		return Collections.singleton("CLGD");
 	}
 
+	@Nonnull
 	@Override
 	public Optional<String> getWebsite() {
 		return Optional.empty();
 	}
 
 	@Override
-	public void configSetup(Group group) {
+	public void configSetup(@Nonnull Group group) {
 		config = new AWTConfig(group);
 	}
 
 	@Override
-	public void setup(PluginManager manager) {
+	public void setup(@Nonnull PluginManager manager) {
 		manager.addRenderer("AWT", new RendererFactory<Renderer>() {
 			private WeakReference<JFrame> lastFrame = null;
 
 			@Override
-			public Renderer create(EmulatedComputer computer, EmuConfig cfg) {
+			public Renderer create(@Nonnull EmulatedComputer computer, @Nonnull EmuConfig cfg) {
 				return new AWTRenderer(computer, cfg, config);
 			}
 
 			@Override
-			public synchronized boolean createConfigEditor(EmuConfig config) {
+			public synchronized boolean createConfigEditor(@Nonnull EmuConfig config) {
 				if (lastFrame != null) {
 					JFrame frame = lastFrame.get();
 					if (frame != null && frame.isVisible()) {

--- a/src/main/java/net/clgd/ccemux/plugins/builtin/CCEmuXAPI.java
+++ b/src/main/java/net/clgd/ccemux/plugins/builtin/CCEmuXAPI.java
@@ -8,6 +8,8 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.*;
 
+import javax.annotation.Nonnull;
+
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.ArrayUtils;
 
@@ -21,7 +23,6 @@ import lombok.extern.slf4j.Slf4j;
 import net.clgd.ccemux.api.config.Group;
 import net.clgd.ccemux.api.emulation.EmulatedComputer;
 import net.clgd.ccemux.api.emulation.Emulator;
-import net.clgd.ccemux.api.emulation.filesystem.VirtualDirectory.Builder;
 import net.clgd.ccemux.api.emulation.filesystem.VirtualFile;
 import net.clgd.ccemux.api.peripheral.Peripheral;
 import net.clgd.ccemux.api.peripheral.PeripheralFactory;
@@ -106,7 +107,7 @@ public class CCEmuXAPI extends Plugin {
 				if (sideId == -1) throw new LuaException("Invalid side");
 
 				PeripheralFactory<?> factory = emu.getPeripheralFactory(peripheral);
-				if(factory == null) throw new LuaException("Invalid peripheral");
+				if (factory == null) throw new LuaException("Invalid peripheral");
 				Peripheral built = factory.create(computer, emu.getConfig());
 
 				// Setup the config for this peripheral. In the future this could be
@@ -130,14 +131,14 @@ public class CCEmuXAPI extends Plugin {
 			});
 		}
 
+		@Nonnull
 		@Override
 		public String[] getMethodNames() {
 			return methods.keySet().toArray(new String[] {});
 		}
 
 		@Override
-		public Object[] callMethod(ILuaContext context, int method, Object[] arguments)
-				throws LuaException, InterruptedException {
+		public Object[] callMethod(@Nonnull ILuaContext context, int method, @Nonnull Object[] arguments) throws LuaException {
 			return new ArrayList<>(methods.values()).get(method).accept(arguments);
 		}
 
@@ -156,56 +157,53 @@ public class CCEmuXAPI extends Plugin {
 		public void startup() {}
 	}
 
+	@Nonnull
 	@Override
 	public String getName() {
 		return "CCEmuX API";
 	}
 
+	@Nonnull
 	@Override
 	public String getDescription() {
 		return "Adds the 'ccemux' Lua API, which adds methods for interacting with the emulator and real computer.\n"
-				+ "Also adds the `emu` program and help ROM files, which use the API.";
+			+ "Also adds the `emu` program and help ROM files, which use the API.";
 	}
 
+	@Nonnull
 	@Override
 	public Optional<String> getVersion() {
 		return Optional.empty();
 	}
 
+	@Nonnull
 	@Override
 	public Collection<String> getAuthors() {
 		return Collections.emptyList();
 	}
 
+	@Nonnull
 	@Override
 	public Optional<String> getWebsite() {
 		return Optional.empty();
 	}
 
 	@Override
-	public void setup(PluginManager manager) {
-		registerHook(new ComputerCreated() {
-			@Override
-			public void onComputerCreated(Emulator emu, EmulatedComputer computer) {
-				computer.addAPI(new API(emu, computer, "ccemux"));
-			}
-		});
+	public void setup(@Nonnull PluginManager manager) {
+		registerHook((ComputerCreated) (emu, computer) -> computer.addAPI(new API(emu, computer, "ccemux")));
 
-		registerHook(new CreatingROM() {
-			@Override
-			public void onCreatingROM(Emulator emu, Builder romBuilder) {
-				try {
-					romBuilder.addEntry(Paths.get("programs/emu.lua"), new VirtualFile(
-							IOUtils.toByteArray(CCEmuXAPI.class.getResourceAsStream("/rom/emu_program.lua"))));
+		registerHook((CreatingROM) (emu, romBuilder) -> {
+			try {
+				romBuilder.addEntry(Paths.get("programs/emu.lua"), new VirtualFile(
+					IOUtils.toByteArray(CCEmuXAPI.class.getResourceAsStream("/rom/emu_program.lua"))));
 
-					romBuilder.addEntry(Paths.get("help/emu.txt"), new VirtualFile(
-							IOUtils.toByteArray(CCEmuXAPI.class.getResourceAsStream("/rom/emu_help.txt"))));
+				romBuilder.addEntry(Paths.get("help/emu.txt"), new VirtualFile(
+					IOUtils.toByteArray(CCEmuXAPI.class.getResourceAsStream("/rom/emu_help.txt"))));
 
-					romBuilder.addEntry(Paths.get("autorun/emu.lua"), new VirtualFile(
-							IOUtils.toByteArray(CCEmuXAPI.class.getResourceAsStream("/rom/emu_completion.lua"))));
-				} catch (IOException e) {
-					log.error("Failed to register ROM entries", e);
-				}
+				romBuilder.addEntry(Paths.get("autorun/emu.lua"), new VirtualFile(
+					IOUtils.toByteArray(CCEmuXAPI.class.getResourceAsStream("/rom/emu_completion.lua"))));
+			} catch (IOException e) {
+				log.error("Failed to register ROM entries", e);
 			}
 		});
 	}

--- a/src/main/java/net/clgd/ccemux/plugins/builtin/HDFontPlugin.java
+++ b/src/main/java/net/clgd/ccemux/plugins/builtin/HDFontPlugin.java
@@ -4,6 +4,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
 
+import javax.annotation.Nonnull;
+
 import com.google.auto.service.AutoService;
 
 import net.clgd.ccemux.api.plugins.Plugin;
@@ -12,26 +14,31 @@ import net.clgd.ccemux.api.rendering.TerminalFont;
 
 @AutoService(Plugin.class)
 public class HDFontPlugin extends Plugin {
+	@Nonnull
 	@Override
 	public String getName() {
 		return "HD Terminal Font";
 	}
 
+	@Nonnull
 	@Override
 	public String getDescription() {
 		return "Replaces the standard CC font with a double resolution font created by Bomb Bloke";
 	}
 
+	@Nonnull
 	@Override
 	public Optional<String> getVersion() {
 		return Optional.empty();
 	}
 
+	@Nonnull
 	@Override
 	public Collection<String> getAuthors() {
 		return Collections.singleton("BombBloke");
 	}
 
+	@Nonnull
 	@Override
 	public Optional<String> getWebsite() {
 		return Optional
@@ -39,7 +46,7 @@ public class HDFontPlugin extends Plugin {
 	}
 
 	@Override
-	public void setup(PluginManager manager) {
+	public void setup(@Nonnull PluginManager manager) {
 		TerminalFont.registerFont(HDFontPlugin.class.getResource("/img/hdfont.png"));
 	}
 }

--- a/src/main/java/net/clgd/ccemux/plugins/builtin/JFXPlugin.java
+++ b/src/main/java/net/clgd/ccemux/plugins/builtin/JFXPlugin.java
@@ -4,6 +4,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
 
+import javax.annotation.Nonnull;
+
 import com.google.auto.service.AutoService;
 
 import net.clgd.ccemux.api.OperatingSystem;
@@ -24,39 +26,44 @@ public class JFXPlugin extends Plugin {
 			OperatingSystem.get().equals(OperatingSystem.MacOSX)).setName("Double font resolution").setDescription(
 					"Scales fonts by a factor of two before rendering. " + "May fix blurriness on high DPI displays.");
 
+	@Nonnull
 	@Override
 	public String getName() {
 		return "JavaFX Renderer";
 	}
 
+	@Nonnull
 	@Override
 	public String getDescription() {
 		return "A renderer using JavaFX";
 	}
 
+	@Nonnull
 	@Override
 	public Optional<String> getVersion() {
 		return Optional.empty();
 	}
 
+	@Nonnull
 	@Override
 	public Collection<String> getAuthors() {
 		return Collections.singleton("CLGD");
 	}
 
+	@Nonnull
 	@Override
 	public Optional<String> getWebsite() {
 		return Optional.empty();
 	}
 
 	@Override
-	public void configSetup(Group group) {
+	public void configSetup(@Nonnull Group group) {
 		group.addProperty(forceUtilityDecoration);
 		group.addProperty(doubleFontScale);
 	}
 
 	@Override
-	public void setup(PluginManager manager) {
+	public void setup(@Nonnull PluginManager manager) {
 		try {
 			Class.forName("javafx.application.Application", false, getClass().getClassLoader());
 		} catch (ClassNotFoundException ignored) {

--- a/src/main/java/net/clgd/ccemux/plugins/builtin/TRoRPlugin.java
+++ b/src/main/java/net/clgd/ccemux/plugins/builtin/TRoRPlugin.java
@@ -4,6 +4,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
 
+import javax.annotation.Nonnull;
+
 import com.google.auto.service.AutoService;
 
 import net.clgd.ccemux.api.plugins.Plugin;
@@ -12,33 +14,38 @@ import net.clgd.ccemux.rendering.tror.TRoRRenderer;
 
 @AutoService(Plugin.class)
 public class TRoRPlugin extends Plugin {
+	@Nonnull
 	@Override
 	public String getName() {
 		return "TRoR Renderer";
 	}
 
+	@Nonnull
 	@Override
 	public String getDescription() {
 		return "A CPU-based renderer which reads from stdin and writes to stdout using the TRoR protocol.";
 	}
 
+	@Nonnull
 	@Override
 	public Optional<String> getVersion() {
 		return Optional.empty();
 	}
 
+	@Nonnull
 	@Override
 	public Collection<String> getAuthors() {
 		return Collections.singleton("CLGD");
 	}
 
+	@Nonnull
 	@Override
 	public Optional<String> getWebsite() {
 		return Optional.empty();
 	}
 
 	@Override
-	public void setup(PluginManager manager) {
+	public void setup(@Nonnull PluginManager manager) {
 		manager.addRenderer("TRoR", TRoRRenderer::new);
 	}
 }

--- a/src/main/java/net/clgd/ccemux/plugins/builtin/peripherals/DefaultPeripheralsPlugin.java
+++ b/src/main/java/net/clgd/ccemux/plugins/builtin/peripherals/DefaultPeripheralsPlugin.java
@@ -4,13 +4,11 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
 
+import javax.annotation.Nonnull;
+
 import com.google.auto.service.AutoService;
 import net.clgd.ccemux.api.config.ConfigProperty;
 import net.clgd.ccemux.api.config.Group;
-import net.clgd.ccemux.api.emulation.EmuConfig;
-import net.clgd.ccemux.api.emulation.EmulatedComputer;
-import net.clgd.ccemux.api.peripheral.Peripheral;
-import net.clgd.ccemux.api.peripheral.PeripheralFactory;
 import net.clgd.ccemux.api.plugins.Plugin;
 import net.clgd.ccemux.api.plugins.PluginManager;
 
@@ -18,33 +16,38 @@ import net.clgd.ccemux.api.plugins.PluginManager;
 public class DefaultPeripheralsPlugin extends Plugin {
 	private ConfigProperty<Long> diskCapacity;
 
+	@Nonnull
 	@Override
 	public String getName() {
 		return "Default Peripherals";
 	}
 
+	@Nonnull
 	@Override
 	public String getDescription() {
 		return "Provides various peripherals which are built-in to ComputerCraft";
 	}
 
+	@Nonnull
 	@Override
 	public Optional<String> getVersion() {
 		return Optional.empty();
 	}
 
+	@Nonnull
 	@Override
 	public Collection<String> getAuthors() {
 		return Collections.singleton("CLGD");
 	}
 
+	@Nonnull
 	@Override
 	public Optional<String> getWebsite() {
 		return Optional.empty();
 	}
 
 	@Override
-	public void configSetup(Group group) {
+	public void configSetup(@Nonnull Group group) {
 		// ComputerCraft.floppySpaceLimit
 		diskCapacity = group.property("disk_capacity", Long.class, 125000L)
 			.setName("Floppy space limit")
@@ -52,22 +55,8 @@ public class DefaultPeripheralsPlugin extends Plugin {
 	}
 
 	@Override
-	@SuppressWarnings("Convert2Lambda")
-	public void setup(PluginManager manager) {
-		// We need to use anonymous classes in order to defer the loading of IPeripheral
-
-		manager.addPeripheral("wireless_modem", new PeripheralFactory<Peripheral>() {
-			@Override
-			public Peripheral create(EmulatedComputer c, EmuConfig e) {
-				return new WirelessModemPeripheral();
-			}
-		});
-
-		manager.addPeripheral("disk_drive", new PeripheralFactory<Peripheral>() {
-			@Override
-			public Peripheral create(EmulatedComputer computer, EmuConfig cfg) {
-				return new DiskDrivePeripheral(cfg.getDataDir(), diskCapacity);
-			}
-		});
+	public void setup(@Nonnull PluginManager manager) {
+		manager.addPeripheral("wireless_modem", (computer, cfg) -> new WirelessModemPeripheral());
+		manager.addPeripheral("disk_drive", (computer, cfg) -> new DiskDrivePeripheral(cfg.getDataDir(), diskCapacity));
 	}
 }

--- a/src/main/java/net/clgd/ccemux/plugins/builtin/peripherals/DiskDrivePeripheral.java
+++ b/src/main/java/net/clgd/ccemux/plugins/builtin/peripherals/DiskDrivePeripheral.java
@@ -41,7 +41,7 @@ public class DiskDrivePeripheral implements Peripheral {
 	}
 
 	@Override
-	public void configSetup(Group group) {
+	public void configSetup(@Nonnull Group group) {
 		mountId = group.property("id", Integer.class, -1)
 			.setName("Disk ID")
 			.setDescription("The ID of the currently inserted disk, set to -1 to eject");

--- a/src/main/java/net/clgd/ccemux/plugins/builtin/peripherals/WirelessModemPeripheral.java
+++ b/src/main/java/net/clgd/ccemux/plugins/builtin/peripherals/WirelessModemPeripheral.java
@@ -33,7 +33,7 @@ public class WirelessModemPeripheral implements Peripheral {
 	private ConfigProperty<Integer> posZ;
 
 	@Override
-	public void configSetup(Group group) {
+	public void configSetup(@Nonnull Group group) {
 		range = group.property("range", Integer.class, 64);
 		interdimensional = group.property("interdimensional", Boolean.class, false);
 
@@ -89,7 +89,7 @@ public class WirelessModemPeripheral implements Peripheral {
 		}
 	}
 
-	public Object[] callMethod(@Nonnull IComputerAccess computer, @Nonnull ILuaContext context, int method, @Nonnull Object[] arguments) throws LuaException, InterruptedException {
+	public Object[] callMethod(@Nonnull IComputerAccess computer, @Nonnull ILuaContext context, int method, @Nonnull Object[] arguments) throws LuaException {
 		switch (method) {
 			case 0: { // open
 				int channel = parseChannel(arguments, 0);

--- a/src/main/java/net/clgd/ccemux/rendering/awt/AWTRenderer.java
+++ b/src/main/java/net/clgd/ccemux/rendering/awt/AWTRenderer.java
@@ -33,6 +33,7 @@ import java.util.Arrays;
 import java.util.BitSet;
 import java.util.List;
 
+import javax.annotation.Nonnull;
 import javax.imageio.ImageIO;
 import javax.swing.InputMap;
 import javax.swing.JOptionPane;
@@ -71,12 +72,12 @@ public class AWTRenderer implements Renderer, KeyListener, MouseListener, MouseM
 	private final Frame frame;
 
 	@Override
-	public void addListener(Renderer.Listener listener) {
+	public void addListener(@Nonnull Renderer.Listener listener) {
 		listeners.add(listener);
 	}
 
 	@Override
-	public void removeListener(Renderer.Listener listener) {
+	public void removeListener(@Nonnull Renderer.Listener listener) {
 		listeners.remove(listener);
 	}
 

--- a/src/main/java/net/clgd/ccemux/rendering/awt/config/CollectionPropertyComponent.java
+++ b/src/main/java/net/clgd/ccemux/rendering/awt/config/CollectionPropertyComponent.java
@@ -19,7 +19,6 @@ public abstract class CollectionPropertyComponent<T, TEntry extends CollectionPr
 	private final Consumer<T> valueChanged;
 
 	protected final JPanel components;
-	private final GridBagLayout layout;
 
 	public CollectionPropertyComponent(Consumer<T> valueChanged) {
 		this.entries = new ArrayList<>();
@@ -37,6 +36,7 @@ public abstract class CollectionPropertyComponent<T, TEntry extends CollectionPr
 			constraints.weighty = 1;
 			constraints.fill = GridBagConstraints.BOTH;
 
+			GridBagLayout layout;
 			components = new JPanel(layout = new GridBagLayout());
 			SwingHelpers.hideBackground(components);
 			add(components, constraints);

--- a/src/main/java/net/clgd/ccemux/rendering/javafx/ConfigBindings.java
+++ b/src/main/java/net/clgd/ccemux/rendering/javafx/ConfigBindings.java
@@ -20,10 +20,9 @@ public class ConfigBindings {
 	/**
 	 * A JavaFX {@link Property} implementation that wraps a
 	 * {@link ConfigProperty}
-	 * 
-	 * @author apemanzilla
 	 *
 	 * @param <T>
+	 * @author apemanzilla
 	 */
 	@RequiredArgsConstructor
 	public static class WrappedConfigProperty<T> extends ObjectProperty<T> {
@@ -124,9 +123,9 @@ public class ConfigBindings {
 
 	/**
 	 * Wraps a given {@link ConfigProperty} as a JavaFX {@link Property}
-	 * 
-	 * @param cfgProp
-	 * @return
+	 *
+	 * @param cfgProp The config property to wrap
+	 * @return The wrapped property
 	 */
 	public static <T> Property<T> wrap(ConfigProperty<T> cfgProp) {
 		return new WrappedConfigProperty<>(cfgProp);

--- a/src/main/java/net/clgd/ccemux/rendering/javafx/ImageRescaler.java
+++ b/src/main/java/net/clgd/ccemux/rendering/javafx/ImageRescaler.java
@@ -2,21 +2,18 @@ package net.clgd.ccemux.rendering.javafx;
 
 import javafx.scene.image.Image;
 import javafx.scene.image.WritableImage;
-import lombok.val;
 import lombok.experimental.UtilityClass;
+import lombok.val;
 
 @UtilityClass
 public class ImageRescaler {
 	/**
 	 * Creates a scaled copy of the given image using nearest-neighbor scaling
-	 * 
-	 * @param base
-	 *            The base image
-	 * @param hscale
-	 *            The horizontal scale value
-	 * @param vscale
-	 *            The vertical scale value
-	 * @return
+	 *
+	 * @param base   The base image
+	 * @param hscale The horizontal scale value
+	 * @param vscale The vertical scale value
+	 * @return The rescaled image
 	 */
 	public static Image rescale(Image base, double hscale, double vscale) {
 		int w = (int) Math.round(base.getWidth() * hscale);

--- a/src/main/java/net/clgd/ccemux/rendering/javafx/JFXMouseTranslator.java
+++ b/src/main/java/net/clgd/ccemux/rendering/javafx/JFXMouseTranslator.java
@@ -5,14 +5,14 @@ import javafx.scene.input.MouseButton;
 public class JFXMouseTranslator {
 	public static int toCC(MouseButton b) {
 		switch (b) {
-		case PRIMARY:
-			return 1;
-		case SECONDARY:
-			return 2;
-		case MIDDLE:
-			return 3;
-		default:
-			return 0;
+			case PRIMARY:
+				return 1;
+			case SECONDARY:
+				return 2;
+			case MIDDLE:
+				return 3;
+			default:
+				return 0;
 		}
 	}
 }

--- a/src/main/java/net/clgd/ccemux/rendering/javafx/JFXRenderer.java
+++ b/src/main/java/net/clgd/ccemux/rendering/javafx/JFXRenderer.java
@@ -3,6 +3,8 @@ package net.clgd.ccemux.rendering.javafx;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import javax.annotation.Nonnull;
+
 import com.google.common.base.Strings;
 
 import javafx.application.Platform;
@@ -86,12 +88,12 @@ public class JFXRenderer implements Renderer {
 	private final Set<Listener> listeners = ConcurrentHashMap.newKeySet();
 
 	@Override
-	public void addListener(Listener l) {
+	public void addListener(@Nonnull Listener l) {
 		listeners.add(l);
 	}
 
 	@Override
-	public void removeListener(Listener l) {
+	public void removeListener(@Nonnull Listener l) {
 		listeners.remove(l);
 	}
 }

--- a/src/main/java/net/clgd/ccemux/rendering/javafx/JFXRendererFactory.java
+++ b/src/main/java/net/clgd/ccemux/rendering/javafx/JFXRendererFactory.java
@@ -8,6 +8,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import javax.annotation.Nonnull;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.stage.Stage;
@@ -23,7 +25,7 @@ public class JFXRendererFactory implements RendererFactory<JFXRenderer> {
 		public static final CountDownLatch latch = new CountDownLatch(1);
 
 		@Override
-		public void start(Stage stage) throws Exception {
+		public void start(Stage stage) {
 			latch.countDown();
 		}
 	}
@@ -37,7 +39,7 @@ public class JFXRendererFactory implements RendererFactory<JFXRenderer> {
 	}
 
 	@Override
-	public JFXRenderer create(EmulatedComputer computer, EmuConfig cfg) {
+	public JFXRenderer create(@Nonnull EmulatedComputer computer, @Nonnull EmuConfig cfg) {
 		try {
 			if (!jfxStarted.getAndSet(true)) {
 				Platform.setImplicitExit(false);

--- a/src/test/java/net/clgd/ccemux/test/VirtualMountTest.java
+++ b/src/test/java/net/clgd/ccemux/test/VirtualMountTest.java
@@ -63,8 +63,8 @@ public class VirtualMountTest {
 
 	@Test
 	public void testFollowInvalidPath() {
-		assertEquals(null, rom.follow(get("nonexistent")));
-		assertEquals(null, rom.follow(get("file/child")));
+		assertNull(rom.follow(get("nonexistent")));
+		assertNull(rom.follow(get("file/child")));
 	}
 
 	@Test


### PR DESCRIPTION
 - Reformat the plugin directory. This mostly strips redundant whitespace, though yell at me if there's anything you don't like.

 - Ensure existing Javadoc has something on all the fields. Also fix some invalid Javadoc references.
 - Use `@code`/`@link` instead of `<code>`
 - Ensure `@Nonnull`/`@Nullable` is used on inherited classes
 - Switch to lambdas where possible (we couldn't do this before due to class-loading limitations).