### PR TITLE
Add a very primitive form of session persistence

### DIFF
--- a/plugin-api/src/main/java/net/clgd/ccemux/api/emulation/EmuConfig.java
+++ b/plugin-api/src/main/java/net/clgd/ccemux/api/emulation/EmuConfig.java
@@ -73,6 +73,10 @@ public abstract class EmuConfig extends Config {
 		.setName("Default computer settings")
 		.setDescription("A comma seperated list of default system settings to set on new computers. Example: \"shell.autocomplete=false,lua.autocomplete=false,edit.autocomplete=false\" will disable all autocompletion");
 
+	public ConfigProperty<Boolean> restoreSession = property("restoreSession", Boolean.class, false)
+		.setName("Restore session")
+		.setDescription("Restore computers from the previous session when starting the emulator");
+
 	public abstract void save() throws IOException;
 
 	public abstract void load() throws IOException;

--- a/src/main/java/net/clgd/ccemux/emulation/SessionState.java
+++ b/src/main/java/net/clgd/ccemux/emulation/SessionState.java
@@ -1,0 +1,80 @@
+package net.clgd.ccemux.emulation;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class SessionState {
+	private static final Gson gson = new GsonBuilder().create();
+
+	/**
+	 * The list of active computers in the session
+	 */
+	public List<ComputerState> computers = Collections.emptyList();
+	public SessionState() {
+	}
+
+	public SessionState(List<ComputerState> computers) {
+		this.computers = computers;
+	}
+
+	/**
+	 * The serialised form of a computer in the current session
+	 */
+	public static final class ComputerState {
+		/**
+		 * The ID for this computer
+		 */
+		public int id;
+
+		/**
+		 * The (optional) label of this computer
+		 */
+		@Nullable
+		public String label;
+
+		public ComputerState() {}
+
+		public ComputerState(int id, @Nullable String label) {
+			this.id = id;
+			this.label = label;
+		}
+	}
+
+	public void save(Path destination) {
+		try {
+			log.info("Saving session to " + destination);
+			try (BufferedWriter writer = Files.newBufferedWriter(destination, StandardCharsets.UTF_8)) {
+				gson.toJson(this, writer);
+			}
+		} catch (IOException e) {
+			log.error("Cannot save session state", e);
+		}
+	}
+
+	@Nullable
+	public static SessionState load(Path destination) {
+		if (!Files.isRegularFile(destination)) return null;
+
+		try {
+			try (BufferedReader reader = Files.newBufferedReader(destination, StandardCharsets.UTF_8)) {
+				return gson.fromJson(reader, SessionState.class);
+			}
+		} catch (IOException e) {
+			log.error("Cannot load session state", e);
+			return null;
+		}
+	}
+}

--- a/src/main/java/net/clgd/ccemux/emulation/SessionState.java
+++ b/src/main/java/net/clgd/ccemux/emulation/SessionState.java
@@ -23,6 +23,7 @@ public class SessionState {
 	 * The list of active computers in the session
 	 */
 	public List<ComputerState> computers = Collections.emptyList();
+
 	public SessionState() {
 	}
 
@@ -54,11 +55,9 @@ public class SessionState {
 	}
 
 	public void save(Path destination) {
-		try {
-			log.info("Saving session to " + destination);
-			try (BufferedWriter writer = Files.newBufferedWriter(destination, StandardCharsets.UTF_8)) {
-				gson.toJson(this, writer);
-			}
+		log.info("Saving session to " + destination);
+		try (BufferedWriter writer = Files.newBufferedWriter(destination, StandardCharsets.UTF_8)) {
+			gson.toJson(this, writer);
 		} catch (IOException e) {
 			log.error("Cannot save session state", e);
 		}
@@ -68,10 +67,8 @@ public class SessionState {
 	public static SessionState load(Path destination) {
 		if (!Files.isRegularFile(destination)) return null;
 
-		try {
-			try (BufferedReader reader = Files.newBufferedReader(destination, StandardCharsets.UTF_8)) {
-				return gson.fromJson(reader, SessionState.class);
-			}
+		try (BufferedReader reader = Files.newBufferedReader(destination, StandardCharsets.UTF_8)) {
+			return gson.fromJson(reader, SessionState.class);
 		} catch (IOException e) {
 			log.error("Cannot load session state", e);
 			return null;


### PR DESCRIPTION
Guarded behind a config option for now (`restoreSession`), this will save the list of open computers to `<data_dir>/session.json`, and load them when the emulator starts.

Closes #118 and fixes #33 

I'm not entirely sure about the implementation, so comments welcome.

I've done a bit of looking into adding an `emu stop` command, so you can close the entire emulator (and thus restore all computers), but need to have a bit more of a thunk about how it works.