### PR TITLE
Allow launching CCEmuX in a specific directory

### DIFF
--- a/plugin-api/src/main/java/net/clgd/ccemux/api/emulation/EmuConfig.java
+++ b/plugin-api/src/main/java/net/clgd/ccemux/api/emulation/EmuConfig.java
@@ -77,6 +77,10 @@ public abstract class EmuConfig extends Config {
 			.setName("Restore session")
 			.setDescription("Restore computers from the previous session when starting the emulator");
 
+	public EmuConfig() {
+		getRoot().setName("CCEmuX Config");
+	}
+
 	public abstract void save() throws IOException;
 
 	public abstract void load() throws IOException;

--- a/src/main/java/net/clgd/ccemux/emulation/CCEmuX.java
+++ b/src/main/java/net/clgd/ccemux/emulation/CCEmuX.java
@@ -33,6 +33,7 @@ import net.clgd.ccemux.api.emulation.filesystem.VirtualMount;
 import net.clgd.ccemux.api.peripheral.PeripheralFactory;
 import net.clgd.ccemux.api.rendering.Renderer;
 import net.clgd.ccemux.api.rendering.RendererFactory;
+import net.clgd.ccemux.init.UserConfig;
 import net.clgd.ccemux.plugins.PluginManager;
 
 @RequiredArgsConstructor
@@ -45,11 +46,11 @@ public class CCEmuX implements Runnable, Emulator, IComputerEnvironment {
 			props.load(s);
 			return props.getProperty("version");
 		} catch (IOException e) {
-			return null;
+			return "UNKNOWN";
 		}
 	}
 
-	private final EmuConfig cfg;
+	private final UserConfig cfg;
 
 	@Getter
 	private final RendererFactory<?> rendererFactory;
@@ -299,7 +300,7 @@ public class CCEmuX implements Runnable, Emulator, IComputerEnvironment {
 
 	@Override
 	public IWritableMount createSaveDirMount(String path, long capacity) {
-		return new FileMount(cfg.getDataDir().resolve("computer").resolve(path).toFile(), getComputerSpaceLimit());
+		return new FileMount(cfg.getComputerDir().resolve(path).toFile(), getComputerSpaceLimit());
 	}
 
 	@Override

--- a/src/main/java/net/clgd/ccemux/init/Launcher.java
+++ b/src/main/java/net/clgd/ccemux/init/Launcher.java
@@ -78,6 +78,7 @@ public class Launcher {
 		if (cli.hasOption('h')) {
 			printHelp();
 			System.exit(0);
+			return;
 		}
 
 		log.info("Starting CCEmuX");

--- a/src/main/java/net/clgd/ccemux/init/UserConfig.java
+++ b/src/main/java/net/clgd/ccemux/init/UserConfig.java
@@ -24,18 +24,25 @@ public class UserConfig extends EmuConfig {
 
 	private final Path dataDir;
 
+	private final Path computerDir;
+
 	private final JsonAdapter adapter;
 
-	public UserConfig(Path dataDir) {
-		adapter = new JsonAdapter(gson, this);
+	public UserConfig(Path dataDir, Path computerDir) {
 		this.dataDir = dataDir;
-		getRoot().setName("CCEmuX Config");
+		this.computerDir = computerDir;
+		this.adapter = new JsonAdapter(gson, this);
 	}
 
 	@Nonnull
 	@Override
 	public Path getDataDir() {
 		return dataDir;
+	}
+
+	@Nonnull
+	public Path getComputerDir() {
+		return computerDir;
 	}
 
 	@Override

--- a/src/main/java/net/clgd/ccemux/init/UserConfigCCTweaked.java
+++ b/src/main/java/net/clgd/ccemux/init/UserConfigCCTweaked.java
@@ -49,8 +49,8 @@ public class UserConfigCCTweaked extends UserConfig {
 		.setDescription("The maximum size (in bytes) that a computer can send or receive in one websocket packet.");
 
 
-	public UserConfigCCTweaked(Path dataDir) {
-		super(dataDir);
+	public UserConfigCCTweaked(Path dataDir, Path computerDir) {
+		super(dataDir, computerDir);
 	}
 
 	@Override


### PR DESCRIPTION
 - Running with `-C` will set the "computers directory" to the given path.    This is like a more specialised version of `--data-dir`, in that it relocates `$DATA_DIR/computer` rather than the all configs.

 - Running with `-c` will launch a new computer mounted on the given folder. This can be specified multiple times (`-c a -c b`). Note that later computers created (including those with an id matching one created with `-c`) will be mounted in the standard computer directory location.

While this is not as flexible or powerful as CCRunX, I think this is still a good step in the right direction. As always, comments and suggestions welcome!