### PR TITLE
 Add system for taking screenshots within the emulator 

### DIFF
--- a/plugin-api/src/main/java/net/clgd/ccemux/api/emulation/EmulatedComputer.java
+++ b/plugin-api/src/main/java/net/clgd/ccemux/api/emulation/EmulatedComputer.java
@@ -97,6 +97,15 @@ public abstract class EmulatedComputer extends Computer {
 	public abstract void copyFiles(@Nonnull Iterable<File> files, @Nonnull String location) throws IOException;
 
 	/**
+	 * Take a screenshot of the current terminal, saving it to a file.
+	 *
+	 * @return The path to the saved screenshot. This will be a {@code .png} file.
+	 * @throws IOException If the file cannot be saved.
+	 */
+	@Nonnull
+	public abstract File screenshot() throws IOException;
+
+	/**
 	 * Queues a key event
 	 */
 	public void pressKey(int keycode, boolean repeat) {

--- a/plugin-api/src/main/java/net/clgd/ccemux/api/emulation/EmulatedComputer.java
+++ b/plugin-api/src/main/java/net/clgd/ccemux/api/emulation/EmulatedComputer.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import com.google.common.util.concurrent.ListenableFuture;
 import dan200.computercraft.api.filesystem.IWritableMount;
 import dan200.computercraft.core.computer.Computer;
 import dan200.computercraft.core.computer.IComputerEnvironment;
@@ -99,11 +100,11 @@ public abstract class EmulatedComputer extends Computer {
 	/**
 	 * Take a screenshot of the current terminal, saving it to a file.
 	 *
-	 * @return The path to the saved screenshot. This will be a {@code .png} file.
-	 * @throws IOException If the file cannot be saved.
+	 * @return A future which contains the path to the saved screenshot, or throws an {@link IOException}. The files is
+	 * guranteed to be a {@code .png} file.
 	 */
 	@Nonnull
-	public abstract File screenshot() throws IOException;
+	public abstract ListenableFuture<File> screenshot();
 
 	/**
 	 * Queues a key event

--- a/src/main/java/net/clgd/ccemux/Utils.java
+++ b/src/main/java/net/clgd/ccemux/Utils.java
@@ -3,6 +3,15 @@ package net.clgd.ccemux;
 import java.io.File;
 import java.io.IOException;
 import java.util.Random;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
+import dan200.computercraft.api.lua.ILuaContext;
+import dan200.computercraft.api.lua.LuaException;
+import net.clgd.ccemux.api.emulation.EmulatedComputer;
 
 public final class Utils {
 	private static final int RETRIES = 10;
@@ -22,5 +31,49 @@ public final class Utils {
 		}
 
 		throw new IOException("Unable to create temporary file");
+	}
+
+	private static class Box {
+		Object[] contents;
+	}
+
+	private static final String TASK_EVENT = "ccemux_task";
+
+	private static final AtomicInteger taskId = new AtomicInteger();
+
+	/**
+	 * Observe a {@link ListenableFuture} and resume the computer when it has completed.
+	 *
+	 * @param computer The computer to resume.
+	 * @param context  The current Lua context.
+	 * @param future   The future to observe.
+	 * @param success  A function to process the results when the future succeeds.
+	 * @param failure  A function to process the exception when the future fails. Currently this cannot throw a
+	 *                 exception.
+	 * @return The result of {@code success} or {@code failure}
+	 * @throws LuaException         If the coroutine is terminated.
+	 * @throws InterruptedException If the computer is interrupted.
+	 */
+	public static <T> Object[] awaitFuture(EmulatedComputer computer, ILuaContext context, ListenableFuture<T> future, Function<T, Object[]> success, Function<Throwable, Object[]> failure) throws LuaException, InterruptedException {
+		int id = taskId.getAndIncrement();
+		Box box = new Box();
+		future.addListener(() -> {
+			try {
+				box.contents = success.apply(future.get());
+			} catch (InterruptedException e) {
+				box.contents = failure.apply(e);
+			} catch (ExecutionException e) {
+				box.contents = failure.apply(e.getCause());
+			}
+
+			computer.queueEvent(TASK_EVENT, new Object[] { id });
+		}, MoreExecutors.directExecutor());
+
+		while (true) {
+			Object[] result = context.pullEvent(TASK_EVENT);
+			if (result.length >= 2 && result[1] instanceof Number && ((Number) result[1]).intValue() == id) {
+				return box.contents;
+			}
+		}
 	}
 }

--- a/src/main/java/net/clgd/ccemux/Utils.java
+++ b/src/main/java/net/clgd/ccemux/Utils.java
@@ -20,17 +20,19 @@ public final class Utils {
 	private Utils() {
 	}
 
+	/**
+	 * Create a unique file with a prefix and suffix, appending random digits if the file already exists.
+	 *
+	 * @param directory The directory to create the file in.
+	 * @param name      The prefix of the name.
+	 * @param extension The suffix of the file, including the ".".
+	 * @return The generated file
+	 * @throws IOException If we cannot create a random file
+	 */
 	public static synchronized File createUniqueFile(File directory, String name, String extension) throws IOException {
 		File file = new File(directory, name + extension);
 		if (file.createNewFile()) return file;
-
-		for (int i = 0; i < RETRIES; i++) {
-			int id = Math.abs(random.nextInt());
-			file = new File(directory, name + "." + id + extension);
-			if (file.createNewFile()) return file;
-		}
-
-		throw new IOException("Unable to create temporary file");
+		return File.createTempFile(name + ".", extension, directory);
 	}
 
 	private static class Box {

--- a/src/main/java/net/clgd/ccemux/Utils.java
+++ b/src/main/java/net/clgd/ccemux/Utils.java
@@ -1,0 +1,26 @@
+package net.clgd.ccemux;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Random;
+
+public final class Utils {
+	private static final int RETRIES = 10;
+	private static Random random = new Random();
+
+	private Utils() {
+	}
+
+	public static synchronized File createUniqueFile(File directory, String name, String extension) throws IOException {
+		File file = new File(directory, name + extension);
+		if (file.createNewFile()) return file;
+
+		for (int i = 0; i < RETRIES; i++) {
+			int id = Math.abs(random.nextInt());
+			file = new File(directory, name + "." + id + extension);
+			if (file.createNewFile()) return file;
+		}
+
+		throw new IOException("Unable to create temporary file");
+	}
+}

--- a/src/main/java/net/clgd/ccemux/emulation/EmulatedComputerImpl.java
+++ b/src/main/java/net/clgd/ccemux/emulation/EmulatedComputerImpl.java
@@ -15,6 +15,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 
@@ -26,6 +27,9 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Objects;
 import com.google.common.io.ByteStreams;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
 import dan200.computercraft.ComputerCraft;
 import dan200.computercraft.api.filesystem.IWritableMount;
 import dan200.computercraft.api.peripheral.IPeripheral;
@@ -41,6 +45,7 @@ import net.clgd.ccemux.rendering.awt.TerminalRenderer;
  */
 public class EmulatedComputerImpl extends EmulatedComputer {
 	private static final Logger log = LoggerFactory.getLogger(EmulatedComputerImpl.class);
+	private static final ListeningExecutorService SCREENSHOTS = MoreExecutors.listeningDecorator(Executors.newSingleThreadExecutor());
 
 	private static final BiConsumer<EmulatedComputer, IWritableMount> setRootMount;
 
@@ -249,37 +254,39 @@ public class EmulatedComputerImpl extends EmulatedComputer {
 
 	@Nonnull
 	@Override
-	public File screenshot() throws IOException {
-		Path screenshotDir = emulator.getConfig().getDataDir().resolve("screenshots");
-		Files.createDirectories(screenshotDir);
+	public ListenableFuture<File> screenshot() {
+		return SCREENSHOTS.submit(() -> {
+			Path screenshotDir = emulator.getConfig().getDataDir().resolve("screenshots");
+			Files.createDirectories(screenshotDir);
 
-		LocalDateTime instant = LocalDateTime.now();
-		File file = Utils.createUniqueFile(screenshotDir.toFile(), String.format("%04d-%02d-%02d-%02d_%02d_%02d",
-			instant.get(ChronoField.YEAR), instant.get(ChronoField.MONTH_OF_YEAR), instant.get(ChronoField.DAY_OF_MONTH),
-			instant.get(ChronoField.HOUR_OF_DAY), instant.get(ChronoField.MINUTE_OF_HOUR), instant.get(ChronoField.SECOND_OF_MINUTE)
-		), ".png");
+			LocalDateTime instant = LocalDateTime.now();
+			File file = Utils.createUniqueFile(screenshotDir.toFile(), String.format("%04d-%02d-%02d-%02d_%02d_%02d",
+				instant.get(ChronoField.YEAR), instant.get(ChronoField.MONTH_OF_YEAR), instant.get(ChronoField.DAY_OF_MONTH),
+				instant.get(ChronoField.HOUR_OF_DAY), instant.get(ChronoField.MINUTE_OF_HOUR), instant.get(ChronoField.SECOND_OF_MINUTE)
+			), ".png");
 
-		AWTTerminalFont font = AWTTerminalFont.getBest(AWTTerminalFont::new);
-		TerminalRenderer renderer = new TerminalRenderer(terminal, emulator.getConfig().termScale.get());
-		try {
-			synchronized (terminal) {
-				Dimension dimension = renderer.getSize();
-				BufferedImage image = new BufferedImage(dimension.width, dimension.height, BufferedImage.TYPE_3BYTE_BGR);
+			AWTTerminalFont font = AWTTerminalFont.getBest(AWTTerminalFont::new);
+			TerminalRenderer renderer = new TerminalRenderer(terminal, emulator.getConfig().termScale.get());
+			try {
+				synchronized (terminal) {
+					Dimension dimension = renderer.getSize();
+					BufferedImage image = new BufferedImage(dimension.width, dimension.height, BufferedImage.TYPE_3BYTE_BGR);
 
-				Graphics graphics = image.getGraphics();
-				renderer.render(font, graphics);
-				graphics.dispose();
+					Graphics graphics = image.getGraphics();
+					renderer.render(font, graphics);
+					graphics.dispose();
 
-				ImageIO.write(image, "png", file);
+					ImageIO.write(image, "png", file);
+				}
+
+				log.info("Saved screenshot to {}", file.getAbsolutePath());
+
+				return file;
+			} catch (IOException e) {
+				file.delete();
+				throw e;
 			}
-
-			log.info("Saved screenshot to {}", file.getAbsolutePath());
-
-			return file;
-		} catch (IOException e) {
-			file.delete();
-			throw e;
-		}
+		});
 	}
 
 	@Override

--- a/src/main/java/net/clgd/ccemux/emulation/EmulatedComputerImpl.java
+++ b/src/main/java/net/clgd/ccemux/emulation/EmulatedComputerImpl.java
@@ -1,9 +1,15 @@
 package net.clgd.ccemux.emulation;
 
+import java.awt.Dimension;
+import java.awt.Graphics;
+import java.awt.image.BufferedImage;
 import java.io.*;
 import java.lang.reflect.Field;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoField;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -13,6 +19,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 
 import javax.annotation.Nonnull;
+import javax.imageio.ImageIO;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,8 +30,11 @@ import dan200.computercraft.ComputerCraft;
 import dan200.computercraft.api.filesystem.IWritableMount;
 import dan200.computercraft.api.peripheral.IPeripheral;
 import dan200.computercraft.core.computer.Computer;
+import net.clgd.ccemux.Utils;
 import net.clgd.ccemux.api.emulation.EmulatedComputer;
 import net.clgd.ccemux.api.emulation.EmulatedTerminal;
+import net.clgd.ccemux.rendering.awt.AWTTerminalFont;
+import net.clgd.ccemux.rendering.awt.TerminalRenderer;
 
 /**
  * Represents a computer that can be emulated via CCEmuX
@@ -234,6 +244,41 @@ public class EmulatedComputerImpl extends EmulatedComputer {
 				mount.makeDirectory(path);
 				copyFiles(Arrays.asList(f.listFiles()), path);
 			}
+		}
+	}
+
+	@Nonnull
+	@Override
+	public File screenshot() throws IOException {
+		Path screenshotDir = emulator.getConfig().getDataDir().resolve("screenshots");
+		Files.createDirectories(screenshotDir);
+
+		LocalDateTime instant = LocalDateTime.now();
+		File file = Utils.createUniqueFile(screenshotDir.toFile(), String.format("%04d-%02d-%02d-%02d_%02d_%02d",
+			instant.get(ChronoField.YEAR), instant.get(ChronoField.MONTH_OF_YEAR), instant.get(ChronoField.DAY_OF_MONTH),
+			instant.get(ChronoField.HOUR_OF_DAY), instant.get(ChronoField.MINUTE_OF_HOUR), instant.get(ChronoField.SECOND_OF_MINUTE)
+		), ".png");
+
+		AWTTerminalFont font = AWTTerminalFont.getBest(AWTTerminalFont::new);
+		TerminalRenderer renderer = new TerminalRenderer(terminal, emulator.getConfig().termScale.get());
+		try {
+			synchronized (terminal) {
+				Dimension dimension = renderer.getSize();
+				BufferedImage image = new BufferedImage(dimension.width, dimension.height, BufferedImage.TYPE_3BYTE_BGR);
+
+				Graphics graphics = image.getGraphics();
+				renderer.render(font, graphics);
+				graphics.dispose();
+
+				ImageIO.write(image, "png", file);
+			}
+
+			log.info("Saved screenshot to {}", file.getAbsolutePath());
+
+			return file;
+		} catch (IOException e) {
+			file.delete();
+			throw e;
 		}
 	}
 

--- a/src/main/java/net/clgd/ccemux/plugins/builtin/CCEmuXAPI.java
+++ b/src/main/java/net/clgd/ccemux/plugins/builtin/CCEmuXAPI.java
@@ -3,7 +3,6 @@ package net.clgd.ccemux.plugins.builtin;
 import java.awt.Desktop;
 import java.awt.Toolkit;
 import java.awt.datatransfer.StringSelection;
-import java.io.File;
 import java.io.IOException;
 import java.util.*;
 
@@ -20,6 +19,7 @@ import dan200.computercraft.core.apis.ArgumentHelper;
 import dan200.computercraft.core.apis.ILuaAPI;
 import dan200.computercraft.core.computer.Computer;
 import dan200.computercraft.core.computer.ComputerThread;
+import net.clgd.ccemux.Utils;
 import net.clgd.ccemux.api.config.Group;
 import net.clgd.ccemux.api.emulation.EmulatedComputer;
 import net.clgd.ccemux.api.emulation.Emulator;
@@ -135,15 +135,12 @@ public class CCEmuXAPI extends Plugin {
 				return null;
 			});
 
-			methods.put("screenshot", (c, o) -> {
-				try {
-					File file = computer.screenshot();
-					return new Object[] { file.getName() };
-				} catch (IOException e) {
+			methods.put("screenshot", (c, o) -> Utils.awaitFuture(computer, c, computer.screenshot(),
+				f -> new Object[] { f.getName() },
+				e -> {
 					log.error("Cannot create screenshot", e);
 					return new Object[] { null, "Cannot create screenshot." };
-				}
-			});
+				}));
 		}
 
 		@Nonnull

--- a/src/main/java/net/clgd/ccemux/plugins/builtin/CCEmuXAPI.java
+++ b/src/main/java/net/clgd/ccemux/plugins/builtin/CCEmuXAPI.java
@@ -3,6 +3,7 @@ package net.clgd.ccemux.plugins.builtin;
 import java.awt.Desktop;
 import java.awt.Toolkit;
 import java.awt.datatransfer.StringSelection;
+import java.io.File;
 import java.io.IOException;
 import java.util.*;
 
@@ -132,6 +133,16 @@ public class CCEmuXAPI extends Plugin {
 				awaitPeripheralChange(computer, c);
 
 				return null;
+			});
+
+			methods.put("screenshot", (c, o) -> {
+				try {
+					File file = computer.screenshot();
+					return new Object[] { file.getName() };
+				} catch (IOException e) {
+					log.error("Cannot create screenshot", e);
+					return new Object[] { null, "Cannot create screenshot." };
+				}
 			});
 		}
 

--- a/src/main/java/net/clgd/ccemux/rendering/awt/AWTRenderer.java
+++ b/src/main/java/net/clgd/ccemux/rendering/awt/AWTRenderer.java
@@ -28,6 +28,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.io.CharStreams;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
 import lombok.Getter;
 import net.clgd.ccemux.api.Utils;
 import net.clgd.ccemux.api.emulation.EmuConfig;
@@ -312,11 +314,14 @@ public class AWTRenderer implements Renderer, KeyListener, MouseListener, MouseM
 		}
 
 		if (!hasModifier && e.getKeyCode() == KeyEvent.VK_F2) {
-			try {
-				computer.screenshot();
-			} catch (IOException ex) {
-				log.error("Cannot take screenshot", ex);
-			}
+			ListenableFuture<File> file = computer.screenshot();
+			file.addListener(() -> {
+				try {
+					file.get();
+				} catch (Throwable ex) {
+					log.error("Cannot take screenshot", ex);
+				}
+			}, MoreExecutors.directExecutor());
 			return;
 		}
 

--- a/src/main/java/net/clgd/ccemux/rendering/awt/AWTRenderer.java
+++ b/src/main/java/net/clgd/ccemux/rendering/awt/AWTRenderer.java
@@ -259,14 +259,14 @@ public class AWTRenderer implements Renderer, KeyListener, MouseListener, MouseM
 				// TODO
 				// termComponent.cursorChar = computer.cursorChar;
 				//AWTTerminalFont font = (AWTTerminalFont) TerminalFonts.getFontsFor(getClass()).getBest(this);
-				termComponent.render(getFont(), dt);
+				termComponent.render(getFont());
 			}
 		}
 	}
 
 	private Point mapPointToCC(Point p) {
-		int px = p.x - termComponent.margin;
-		int py = p.y - termComponent.margin;
+		int px = p.x - termComponent.getMargin();
+		int py = p.y - termComponent.getMargin();
 
 		int x = px / pixelWidth;
 		int y = py / pixelHeight;
@@ -307,6 +307,15 @@ public class AWTRenderer implements Renderer, KeyListener, MouseListener, MouseM
 				computer.paste((String) Toolkit.getDefaultToolkit().getSystemClipboard().getData(DataFlavor.stringFlavor));
 			} catch (HeadlessException | UnsupportedFlavorException | IOException er) {
 				log.error("Could not read clipboard", er);
+			}
+			return;
+		}
+
+		if (!hasModifier && e.getKeyCode() == KeyEvent.VK_F2) {
+			try {
+				computer.screenshot();
+			} catch (IOException ex) {
+				log.error("Cannot take screenshot", ex);
 			}
 			return;
 		}

--- a/src/main/java/net/clgd/ccemux/rendering/awt/TerminalRenderer.java
+++ b/src/main/java/net/clgd/ccemux/rendering/awt/TerminalRenderer.java
@@ -1,0 +1,170 @@
+package net.clgd.ccemux.rendering.awt;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.awt.image.RescaleOp;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.Nonnull;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import dan200.computercraft.core.terminal.Terminal;
+import dan200.computercraft.core.terminal.TextBuffer;
+import net.clgd.ccemux.api.Utils;
+import net.clgd.ccemux.api.rendering.PaletteAdapter;
+
+/**
+ * Renders a terminal to arbitrary {@link java.awt.Graphics} objects. This is suitable both for taking
+ * screenshots and rendering to the screen.
+ */
+public class TerminalRenderer {
+	private static final Logger log = LoggerFactory.getLogger(TerminalRenderer.class);
+
+	private static final char CURSOR_CHAR = '_';
+
+	private static final PaletteAdapter.ColorAdapter<Color> AWT_COLOR_ADAPTER = (r, g, b) -> new Color((float) r, (float) g, (float) b);
+
+	private final PaletteAdapter<Color> paletteCacher;
+
+	private final Terminal terminal;
+	private final int pixelWidth;
+	private final int pixelHeight;
+	final int margin;
+
+	private static final Cache<CharImageRequest, BufferedImage> charImgCache = CacheBuilder.newBuilder()
+		.expireAfterAccess(10, TimeUnit.SECONDS).build();
+
+	public TerminalRenderer(Terminal terminal, double termScale) {
+		this.pixelWidth = (int) (6 * termScale);
+		this.pixelHeight = (int) (9 * termScale);
+		this.margin = (int) (2 * termScale);
+		this.terminal = terminal;
+		this.paletteCacher = new PaletteAdapter<>(terminal.getPalette(), AWT_COLOR_ADAPTER);
+	}
+
+	public int getMargin() {
+		return margin;
+	}
+
+	/**
+	 * Get the requested size of the terminal.
+	 *
+	 * Note, you should probably keep a lock on the renderer's terminal
+	 *
+	 * @return The terminal's size.
+	 */
+	public Dimension getSize() {
+		return new Dimension(
+			terminal.getWidth() * pixelWidth + margin * 2,
+			terminal.getHeight() * pixelHeight + margin * 2
+		);
+	}
+
+	private void drawChar(AWTTerminalFont font, Graphics g, char c, int x, int y, int color) {
+		if (c == '\0' || Character.isSpaceChar(c)) return;
+
+		Rectangle r = font.getCharCoords(c);
+		Color colour = paletteCacher.getColor(color, PaletteAdapter.DEFAULT_FOREGROUND);
+
+		BufferedImage charImg = null;
+
+		float[] zero = new float[4];
+
+		try {
+			charImg = charImgCache.get(new CharImageRequest(c, colour, font), () -> {
+				float[] rgb = new float[4];
+				colour.getRGBComponents(rgb);
+
+				RescaleOp rop = new RescaleOp(rgb, zero, null);
+
+				GraphicsConfiguration gc = GraphicsEnvironment.getLocalGraphicsEnvironment().getDefaultScreenDevice()
+					.getDefaultConfiguration();
+
+				BufferedImage img = font.getBitmap().getSubimage(r.x, r.y, r.width, r.height);
+				BufferedImage pixel = gc.createCompatibleImage(r.width, r.height, Transparency.TRANSLUCENT);
+
+				Graphics ig = pixel.getGraphics();
+				ig.drawImage(img, 0, 0, null);
+				ig.dispose();
+
+				rop.filter(pixel, pixel);
+				return pixel;
+			});
+		} catch (ExecutionException e) {
+			log.error("Could not retrieve char image from cache!", e);
+		}
+
+		g.drawImage(charImg, x, y, pixelWidth, pixelHeight, null);
+	}
+
+	public void render(AWTTerminalFont font, Graphics g) {
+		int dx = 0;
+		int dy = 0;
+
+		for (int y = 0; y < terminal.getHeight(); y++) {
+			TextBuffer textLine = terminal.getLine(y);
+			TextBuffer bgLine = terminal.getBackgroundColourLine(y);
+			TextBuffer fgLine = terminal.getTextColourLine(y);
+
+			int height = (y == 0 || y == terminal.getHeight() - 1) ? pixelHeight + margin : pixelHeight;
+
+			for (int x = 0; x < terminal.getWidth(); x++) {
+				int width = (x == 0 || x == terminal.getWidth() - 1) ? pixelWidth + margin : pixelWidth;
+
+				g.setColor(paletteCacher.getColor(bgLine == null ? 'f' : bgLine.charAt(x), PaletteAdapter.DEFAULT_BACKGROUND));
+				g.fillRect(dx, dy, width, height);
+
+				char character = (textLine == null) ? ' ' : textLine.charAt(x);
+				char fgChar = (fgLine == null) ? ' ' : fgLine.charAt(x);
+
+				drawChar(font, g, character, x * pixelWidth + margin, y * pixelHeight + margin,
+					Utils.base16ToInt(fgChar));
+
+				dx += width;
+			}
+
+			dx = 0;
+			dy += height;
+		}
+
+		if (terminal.getCursorBlink() && Utils.getGlobalCursorBlink()) {
+			drawChar(font, g, CURSOR_CHAR, terminal.getCursorX() * pixelWidth + margin,
+				terminal.getCursorY() * pixelHeight + margin, terminal.getTextColour());
+		}
+	}
+
+	private static class CharImageRequest {
+		private final char character;
+		private final Color color;
+		private final AWTTerminalFont font;
+
+		private CharImageRequest(char character, @Nonnull Color color, @Nonnull AWTTerminalFont font) {
+			this.character = character;
+			this.color = color;
+			this.font = font;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) return true;
+			if (o == null || getClass() != o.getClass()) return false;
+
+			CharImageRequest that = (CharImageRequest) o;
+
+			return character == that.character && color.equals(that.color) && font.equals(that.font);
+		}
+
+		@Override
+		public int hashCode() {
+			int result = character;
+			result = 31 * result + color.hashCode();
+			result = 31 * result + font.hashCode();
+			return result;
+		}
+	}
+}


### PR DESCRIPTION
It's not perfect by any measure, but it's at least a half-decent stab at the first half of #34.

 - Adds an `EmulatedComputer.screenshot()` method. This renders the
   terminal and saves a screenshot to `$DATA/screenshots/%Y-%m-%d-%H_%M_%S.png`
 - Rendering is _always_ done using AWT's BufferedImage, rather than being handled by the rendering backend. AWT should be available everywhere, so I don't think this is a problem.
 - Pressing F2 within the AWT renderer will take a screenshot.
 - `ccemux.screenshot()` can be used within CraftOS.