### PR TITLE
Rewrite how mounts are injected

### DIFF
--- a/plugin-api/src/main/java/net/clgd/ccemux/api/emulation/EmulatedComputer.java
+++ b/plugin-api/src/main/java/net/clgd/ccemux/api/emulation/EmulatedComputer.java
@@ -2,6 +2,7 @@ package net.clgd.ccemux.api.emulation;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.function.Supplier;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -42,11 +43,12 @@ public abstract class EmulatedComputer extends Computer {
 		 * the root mount to {@code null} (the default value) will result in one
 		 * being created by the environment.
 		 *
-		 * @param rootMount The writable mount to use as a root mount
+		 * @param rootMount A factory which constructs the writable mount to use as a root mount. This may be
+		 *                  {@code null}, or return {@code null}.
 		 * @return This builder, for chaining
 		 */
 		@Nonnull
-		Builder rootMount(@Nullable IWritableMount rootMount);
+		Builder rootMount(@Nullable Supplier<IWritableMount> rootMount);
 
 		/**
 		 * Sets the label of the computer to construct. Setting the label to

--- a/plugin-api/src/main/java/net/clgd/ccemux/api/emulation/EmulatedComputer.java
+++ b/plugin-api/src/main/java/net/clgd/ccemux/api/emulation/EmulatedComputer.java
@@ -51,6 +51,21 @@ public abstract class EmulatedComputer extends Computer {
 		Builder rootMount(@Nullable Supplier<IWritableMount> rootMount);
 
 		/**
+		 * Sets the root ({@code /}) mount of the computer to construct. Setting
+		 * the root mount to {@code null} (the default value) will result in one
+		 * being created by the environment.
+		 *
+		 * @param rootMount The writable mount to use as a root mount.
+		 * @return This builder, for chaining
+		 * @deprecated Use the {@link #rootMount(Supplier)} override.
+		 */
+		@Nonnull
+		@Deprecated
+		default Builder rootMount(@Nullable IWritableMount rootMount) {
+			return rootMount(() -> rootMount);
+		}
+
+		/**
 		 * Sets the label of the computer to construct. Setting the label to
 		 * {@code null} (the default value) will result in no label being set.
 		 *

--- a/src/main/java/net/clgd/ccemux/emulation/CCEmuX.java
+++ b/src/main/java/net/clgd/ccemux/emulation/CCEmuX.java
@@ -1,8 +1,9 @@
 package net.clgd.ccemux.emulation;
 
-import java.io.*;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
@@ -15,21 +16,11 @@ import javax.annotation.Nonnull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import dan200.computercraft.ComputerCraft;
-import dan200.computercraft.api.filesystem.IMount;
-import dan200.computercraft.api.filesystem.IWritableMount;
-import dan200.computercraft.core.computer.IComputerEnvironment;
-import dan200.computercraft.core.filesystem.ComboMount;
-import dan200.computercraft.core.filesystem.FileMount;
-import dan200.computercraft.core.filesystem.JarMount;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import net.clgd.ccemux.api.emulation.EmuConfig;
 import net.clgd.ccemux.api.emulation.EmulatedComputer;
 import net.clgd.ccemux.api.emulation.EmulatedTerminal;
 import net.clgd.ccemux.api.emulation.Emulator;
-import net.clgd.ccemux.api.emulation.filesystem.VirtualDirectory;
-import net.clgd.ccemux.api.emulation.filesystem.VirtualMount;
 import net.clgd.ccemux.api.peripheral.PeripheralFactory;
 import net.clgd.ccemux.api.rendering.Renderer;
 import net.clgd.ccemux.api.rendering.RendererFactory;
@@ -37,7 +28,7 @@ import net.clgd.ccemux.init.UserConfig;
 import net.clgd.ccemux.plugins.PluginManager;
 
 @RequiredArgsConstructor
-public class CCEmuX implements Runnable, Emulator, IComputerEnvironment {
+public class CCEmuX implements Runnable, Emulator {
 	private static final Logger log = LoggerFactory.getLogger(CCEmuX.class);
 
 	public static String getVersion() {
@@ -71,7 +62,7 @@ public class CCEmuX implements Runnable, Emulator, IComputerEnvironment {
 
 	@Nonnull
 	@Override
-	public EmuConfig getConfig() {
+	public UserConfig getConfig() {
 		return cfg;
 	}
 
@@ -250,85 +241,7 @@ public class CCEmuX implements Runnable, Emulator, IComputerEnvironment {
 		return (System.currentTimeMillis() - started) / 50;
 	}
 
-	@Override
 	public int assignNewID() {
 		return nextID++;
-	}
-
-	@Override
-	public IMount createResourceMount(String domain, String subPath) {
-		String path = Paths.get("assets", domain, subPath).toString().replace('\\', '/');
-		if (path.startsWith("/")) path = path.substring(1);
-
-		JarMount jarMount;
-		try {
-			jarMount = new JarMount(ccSource, path);
-		} catch (IOException e) {
-			log.error("Could not create mount from mod jar", e);
-			return null;
-		}
-
-		VirtualDirectory.Builder romBuilder = new VirtualDirectory.Builder();
-		pluginMgr.onCreatingROM(this, romBuilder);
-
-		return new ComboMount(new IMount[] {
-			// From ComputerCraft JAR
-			jarMount,
-			// From plugin files
-			new VirtualMount(romBuilder.build()),
-			// From data directory
-			new FileMount(cfg.getAssetDir().resolve(path).toFile(), 0)
-		});
-	}
-
-	@Override
-	public InputStream createResourceFile(String domain, String subPath) {
-		String path = Paths.get("assets", domain, subPath).toString().replace('\\', '/');
-		if (path.startsWith("/")) path = path.substring(1);
-
-		File assetFile = cfg.getAssetDir().resolve(path).toFile();
-		if (assetFile.exists() && assetFile.isFile()) {
-			try {
-				return new FileInputStream(assetFile);
-			} catch (FileNotFoundException e) {
-				log.error("Failed to create resource file", e);
-			}
-		}
-
-		return CCEmuX.class.getClassLoader().getResourceAsStream(path);
-	}
-
-	@Override
-	public IWritableMount createSaveDirMount(String path, long capacity) {
-		return new FileMount(cfg.getComputerDir().resolve(path).toFile(), getComputerSpaceLimit());
-	}
-
-	@Override
-	public long getComputerSpaceLimit() {
-		return cfg.maxComputerCapacity.get();
-	}
-
-	@Override
-	public int getDay() {
-		return (int) (((getTicksSinceStart() + 6000) / 24000) + 1);
-	}
-
-	@Override
-	public String getHostString() {
-		if (getVersion() != null) {
-			return String.format("ComputerCraft %s (CCEmuX %s)", ComputerCraft.getVersion(), getVersion());
-		} else {
-			return String.format("ComputerCraft %s (CCEmuX)", ComputerCraft.getVersion());
-		}
-	}
-
-	@Override
-	public double getTimeOfDay() {
-		return ((getTicksSinceStart() + 6000) % 24000) / 1000d;
-	}
-
-	@Override
-	public boolean isColour() {
-		return true;
 	}
 }

--- a/src/main/java/net/clgd/ccemux/emulation/ComputerEnvironment.java
+++ b/src/main/java/net/clgd/ccemux/emulation/ComputerEnvironment.java
@@ -104,13 +104,13 @@ class ComputerEnvironment implements IComputerEnvironment {
 	public IWritableMount createSaveDirMount(String path, long capacity) {
 		// createSaveDirMount should only be called with computer/$id.
 		if (!path.equals("computer/" + id)) {
-			log.error("Unexpected call to createSaveDirMount for {}", capacity);
+			log.error("Unexpected call to createSaveDirMount for {}", path);
 			return new FileMount(emu.getConfig().getComputerDir().resolve(path).toFile(), capacity);
 		}
 
 		return Optional.ofNullable(mount)
 			.map(Supplier::get)
-			.orElseGet(() -> new FileMount(emu.getConfig().getComputerDir().resolve(path).toFile(), capacity));
+			.orElseGet(() -> new FileMount(emu.getConfig().getComputerDir().resolve(Integer.toString(id)).toFile(), capacity));
 	}
 
 	@Override

--- a/src/main/java/net/clgd/ccemux/emulation/ComputerEnvironment.java
+++ b/src/main/java/net/clgd/ccemux/emulation/ComputerEnvironment.java
@@ -1,0 +1,125 @@
+package net.clgd.ccemux.emulation;
+
+import java.io.*;
+import java.nio.file.Paths;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import dan200.computercraft.ComputerCraft;
+import dan200.computercraft.api.filesystem.IMount;
+import dan200.computercraft.api.filesystem.IWritableMount;
+import dan200.computercraft.core.computer.IComputerEnvironment;
+import dan200.computercraft.core.filesystem.ComboMount;
+import dan200.computercraft.core.filesystem.FileMount;
+import dan200.computercraft.core.filesystem.JarMount;
+import net.clgd.ccemux.api.emulation.filesystem.VirtualDirectory;
+import net.clgd.ccemux.api.emulation.filesystem.VirtualMount;
+
+class ComputerEnvironment implements IComputerEnvironment {
+	private static final Logger log = LoggerFactory.getLogger(ComputerEnvironment.class);
+
+	private final CCEmuX emu;
+	private final int id;
+	private final Supplier<IWritableMount> mount;
+
+	ComputerEnvironment(CCEmuX emu, int id, Supplier<IWritableMount> mount) {
+		this.emu = emu;
+		this.id = id;
+		this.mount = mount;
+	}
+
+	@Override
+	public long getComputerSpaceLimit() {
+		return emu.getConfig().maxComputerCapacity.get();
+	}
+
+	@Override
+	public int getDay() {
+		return (int) (((emu.getTicksSinceStart() + 6000) / 24000) + 1);
+	}
+
+	@Override
+	public String getHostString() {
+		String version = CCEmuX.getVersion();
+		if (version != null) {
+			return String.format("ComputerCraft %s (CCEmuX %s)", ComputerCraft.getVersion(), version);
+		} else {
+			return String.format("ComputerCraft %s (CCEmuX)", ComputerCraft.getVersion());
+		}
+	}
+
+	@Override
+	public int assignNewID() {
+		return emu.assignNewID();
+	}
+
+
+	@Override
+	public IMount createResourceMount(String domain, String subPath) {
+		String path = Paths.get("assets", domain, subPath).toString().replace('\\', '/');
+		if (path.startsWith("/")) path = path.substring(1);
+
+		JarMount jarMount;
+		try {
+			jarMount = new JarMount(emu.getCCJar(), path);
+		} catch (IOException e) {
+			log.error("Could not create mount from mod jar", e);
+			return null;
+		}
+
+		VirtualDirectory.Builder romBuilder = new VirtualDirectory.Builder();
+		emu.getPluginMgr().onCreatingROM(emu, romBuilder);
+
+		return new ComboMount(new IMount[] {
+			// From ComputerCraft JAR
+			jarMount,
+			// From plugin files
+			new VirtualMount(romBuilder.build()),
+			// From data directory
+			new FileMount(emu.getConfig().getAssetDir().resolve(path).toFile(), 0)
+		});
+	}
+
+	@Override
+	public InputStream createResourceFile(String domain, String subPath) {
+		String path = Paths.get("assets", domain, subPath).toString().replace('\\', '/');
+		if (path.startsWith("/")) path = path.substring(1);
+
+		File assetFile = emu.getConfig().getAssetDir().resolve(path).toFile();
+		if (assetFile.exists() && assetFile.isFile()) {
+			try {
+				return new FileInputStream(assetFile);
+			} catch (FileNotFoundException e) {
+				log.error("Failed to create resource file", e);
+			}
+		}
+
+		return CCEmuX.class.getClassLoader().getResourceAsStream(path);
+	}
+
+	@Override
+	public IWritableMount createSaveDirMount(String path, long capacity) {
+		// createSaveDirMount should only be called with computer/$id.
+		if (!path.equals("computer/" + id)) {
+			log.error("Unexpected call to createSaveDirMount for {}", capacity);
+			return new FileMount(emu.getConfig().getComputerDir().resolve(path).toFile(), capacity);
+		}
+
+		return Optional.ofNullable(mount)
+			.map(Supplier::get)
+			.orElseGet(() -> new FileMount(emu.getConfig().getComputerDir().resolve(path).toFile(), capacity));
+	}
+
+	@Override
+	public double getTimeOfDay() {
+		return ((emu.getTicksSinceStart() + 6000) % 24000) / 1000d;
+	}
+
+	@Override
+	public boolean isColour() {
+		return true;
+	}
+}

--- a/src/main/java/net/clgd/ccemux/emulation/EmulatedComputerImpl.java
+++ b/src/main/java/net/clgd/ccemux/emulation/EmulatedComputerImpl.java
@@ -111,7 +111,10 @@ public class EmulatedComputerImpl extends EmulatedComputer {
 		public EmulatedComputer build() {
 			if (built.getAndSet(true)) throw new IllegalStateException("This computer has already been built!");
 
-			EmulatedComputer ec = new EmulatedComputerImpl(emu, term, Optional.ofNullable(this.id).orElseGet(emu::assignNewID), rootMount);
+			int id = Optional.ofNullable(this.id).orElse(-1);
+			if (id < 0) id = emu.assignNewID();
+
+			EmulatedComputer ec = new EmulatedComputerImpl(emu, term, id, rootMount);
 			ec.setLabel(label);
 			return ec;
 		}

--- a/src/main/java/net/clgd/ccemux/init/Launcher.java
+++ b/src/main/java/net/clgd/ccemux/init/Launcher.java
@@ -292,7 +292,7 @@ public class Launcher {
 			// Either load the requested computers, restore the session or add a new computer
 			if (startDirs.size() > 0) {
 				for (Path dir : startDirs) {
-					emu.createComputer(b -> b.rootMount(new FileMount(dir.toFile(), ComputerCraft.computerSpaceLimit)));
+					emu.createComputer(b -> b.rootMount(() -> new FileMount(dir.toFile(), ComputerCraft.computerSpaceLimit)));
 				}
 			} else {
 				SessionState session = cfg.restoreSession.get() ? SessionState.load(sessionPath) : null;


### PR DESCRIPTION
 - Move `IComputerEnvironment` implementation to a separate class.
 - Instead of injecting mounts by setting a field, we override `createSaveDirMount` to either construct a standard mount, or use the
   custom supplier.

   This means that computers are created (and thus rendered) immediately, rather than waiting for file scanning to complete. Closes #132